### PR TITLE
fix: make country validation case-insensitive

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -193,7 +193,9 @@ except ImportError as e:
         def validate_country_and_location(cls):
             country = cls.COUNTRY
             location = cls.LOCATION
-            if country not in cls.SUPPORTED_COUNTRIES:
+            # Case-insensitive matching
+            country_map = {c.lower(): c for c in cls.SUPPORTED_COUNTRIES}
+            if country.lower() not in country_map:
                 raise ValueError(f"Invalid country '{country}'")
             if not location or len(location.strip()) < 2:
                 raise ValueError("Location is required")

--- a/config/settings_v2.py
+++ b/config/settings_v2.py
@@ -108,9 +108,11 @@ class Settings(BaseSettings):
     @field_validator("country")
     @classmethod
     def validate_country(cls, v: str) -> str:
-        if v not in SUPPORTED_COUNTRIES:
+        # Case-insensitive matching, return properly cased country name
+        country_map = {c.lower(): c for c in SUPPORTED_COUNTRIES}
+        if v.lower() not in country_map:
             raise ValueError(f"Invalid country: {v}")
-        return v
+        return country_map[v.lower()]
 
 try:
     settings = Settings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -36,6 +36,20 @@ class TestSettingsValidation:
             s = Settings()
             assert s.country == "USA"
 
+    def test_country_validation_case_insensitive(self):
+        """Test country validation is case-insensitive."""
+        from config.settings_v2 import Settings
+
+        # Lowercase should work and be normalized to proper case
+        with patch.dict(os.environ, {"COUNTRY": "australia"}, clear=True):
+            s = Settings()
+            assert s.country == "Australia"
+
+        # Mixed case should also work
+        with patch.dict(os.environ, {"COUNTRY": "UNITED ARAB EMIRATES"}, clear=True):
+            s = Settings()
+            assert s.country == "United Arab Emirates"
+
     def test_country_validation_invalid(self):
         """Test invalid country raises error."""
         from config.settings_v2 import Settings


### PR DESCRIPTION
## Problem
Users were getting `Invalid country: australia` error when using lowercase country names in their `.env` file.

## Root Cause
The `SUPPORTED_COUNTRIES` list uses title case (e.g., `Australia`) but the validator was doing exact string matching without normalizing case.

## Solution
- Updated `settings_v2.py` field_validator to use case-insensitive matching
- Updated legacy `settings.py` validation for consistency
- The validator now normalizes to proper case (e.g., `australia` → `Australia`)

## Testing
- Added test for case-insensitive country validation
- Verified both lowercase (`australia`) and uppercase (`UNITED ARAB EMIRATES`) work correctly

Fixes #7