### PR TITLE
Add application workspace workflow

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -15,6 +15,20 @@ jobs:
   # Run tests first - builds only proceed if tests pass
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: winningcv_test
+          POSTGRES_PASSWORD: winningcv_test
+          POSTGRES_DB: winningcv_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U winningcv_test -d winningcv_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +53,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_api_integration.py tests/test_task_queue.py -v --tb=short
+          pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_postgres_persistence.py tests/test_job_result_workspace.py tests/test_job_processor.py tests/test_api_integration.py tests/test_task_queue.py -v --tb=short
         env:
           AIRTABLE_PAT: "fake_for_testing"
           AIRTABLE_BASE_ID: "fake_base"
@@ -50,6 +64,7 @@ jobs:
           AZURE_AI_ENDPOINT: "https://fake.openai.azure.com"
           AZURE_AI_API_KEY: "fake_key"
           AZURE_DEPLOYMENT: "fake_deployment"
+          TEST_POSTGRES_DSN: "postgresql://winningcv_test:winningcv_test@localhost:5432/winningcv_test"
 
       - name: Validate deployment checks
         run: |

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -171,7 +171,7 @@ jobs:
           host: ${{ secrets.AZURE_VM_HOST }}
           username: ${{ secrets.AZURE_VM_USER }}
           key: ${{ secrets.AZURE_VM_SSH_KEY }}
-          source: "docker-compose.yml,scripts/deploy.sh,scripts/prod_smoke_check.sh,scripts/prod_monitor.sh,scripts/prod_monitor_cron.sh,scripts/install_prod_monitor_cron.sh,scripts/validate_prod_config.sh,scripts/prod_migrate_db.sh,init-db/02-data-storage-schema.sql,init-db/03-migration-v2.sql"
+          source: "docker-compose.yml,scripts/deploy.sh,scripts/prod_smoke_check.sh,scripts/prod_monitor.sh,scripts/prod_monitor_cron.sh,scripts/install_prod_monitor_cron.sh,scripts/validate_prod_config.sh,scripts/prod_migrate_db.sh,init-db/02-data-storage-schema.sql,init-db/03-migration-v2.sql,init-db/06-jobs-user-link-uniqueness.sql"
           target: "~/winning-cv"
           overwrite: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,20 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: winningcv_test
+          POSTGRES_PASSWORD: winningcv_test
+          POSTGRES_DB: winningcv_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U winningcv_test -d winningcv_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       matrix:
         python-version: ['3.11', '3.12']
@@ -109,7 +123,7 @@ jobs:
       - name: Run unit tests
         run: |
           # Run unit tests that don't require external services
-          pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_api_integration.py tests/test_task_queue.py tests/test_job_result_workspace.py -v --tb=short
+          pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_api_integration.py tests/test_task_queue.py tests/test_job_result_workspace.py tests/test_postgres_persistence.py -v --tb=short
         env:
           # Minimal env vars for Config to load
           AIRTABLE_PAT: "fake_for_testing"
@@ -121,6 +135,7 @@ jobs:
           AZURE_AI_ENDPOINT: "https://fake.openai.azure.com"
           AZURE_AI_API_KEY: "fake_key"
           AZURE_DEPLOYMENT: "fake_deployment"
+          TEST_POSTGRES_DSN: "postgresql://winningcv_test:winningcv_test@localhost:5432/winningcv_test"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Run unit tests
         run: |
           # Run unit tests that don't require external services
-          pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_api_integration.py tests/test_task_queue.py tests/test_job_result_workspace.py tests/test_postgres_persistence.py -v --tb=short
+          pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_api_integration.py tests/test_task_queue.py tests/test_job_result_workspace.py tests/test_postgres_persistence.py tests/test_job_processor.py -v --tb=short
         env:
           # Minimal env vars for Config to load
           AIRTABLE_PAT: "fake_for_testing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Test
+        run: npm test
 
       - name: Lint
         run: npm run lint
@@ -106,7 +109,7 @@ jobs:
       - name: Run unit tests
         run: |
           # Run unit tests that don't require external services
-          pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_api_integration.py tests/test_task_queue.py -v --tb=short
+          pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_api_integration.py tests/test_task_queue.py tests/test_job_result_workspace.py -v --tb=short
         env:
           # Minimal env vars for Config to load
           AIRTABLE_PAT: "fake_for_testing"

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -30,7 +30,7 @@ from api.schemas.jobs import (
 from config.settings import Config
 
 # Import storage factory for backend-agnostic access
-from data_store.storage_factory import get_data_manager, get_history_manager, get_cv_version_manager
+from data_store.storage_factory import get_cv_version_manager, get_data_manager, get_history_manager
 from job_processing.core import JobProcessor
 from job_sources.linkedin_cookie_manager import get_cookie_manager
 from ui.helpers import upload_pdf_to_wordpress
@@ -654,106 +654,97 @@ async def get_user_search_tasks(
     ]
 
 
+def _user_jobs_formula(user_email: str) -> str:
+    """Build an Airtable-compatible, escaped user ownership filter."""
+    safe_email = user_email.replace("'", "\\'")
+    return f"{{User Email}} = '{safe_email}'"
+
+
+def _cv_dates_by_url(history_records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Map generated CV URLs to their creation timestamps."""
+    cv_dates = {}
+    for record in history_records:
+        fields = record.get("fields", {})
+        cv_url = fields.get("cv_pdf_url", "")
+        created_at = fields.get("created_at")
+        if cv_url and created_at:
+            cv_dates[cv_url] = created_at
+    return cv_dates
+
+
+def _job_result_from_record(rec: Dict[str, Any], cv_dates: Dict[str, Any]) -> JobResult:
+    """Convert a storage record into the public job result shape."""
+    fields = rec.get("fields", {})
+    reasons_raw = fields.get("Match Reasons", "")
+    suggestions_raw = fields.get("Match Suggestions", "")
+    reasons = reasons_raw.split("\n") if reasons_raw else None
+    suggestions = suggestions_raw.split("\n") if suggestions_raw else None
+
+    cv_link = fields.get("CV Link") or None
+    cv_generated_at = None
+    if cv_link and cv_link in cv_dates:
+        try:
+            cv_generated_at = datetime.fromisoformat(cv_dates[cv_link].replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            pass
+
+    score_breakdown = None
+    ats_score = fields.get("Matching Score")
+    hr_score = fields.get("HR Score")
+    if ats_score is not None or hr_score is not None:
+        matched_kw_raw = fields.get("Matched Keywords", "")
+        missing_kw_raw = fields.get("Missing Keywords", "")
+        matched_keywords = [kw.strip() for kw in matched_kw_raw.split(",") if kw.strip()] if matched_kw_raw else None
+        missing_keywords = [kw.strip() for kw in missing_kw_raw.split(",") if kw.strip()] if missing_kw_raw else None
+        score_breakdown = ScoreBreakdown(
+            ats_score=float(ats_score) if ats_score else None,
+            hr_score=float(hr_score) if hr_score else None,
+            llm_score=float(fields.get("LLM Score")) if fields.get("LLM Score") else None,
+            recommendation=fields.get("HR Recommendation"),
+            matched_keywords=matched_keywords,
+            missing_keywords=missing_keywords,
+        )
+
+    return JobResult(
+        id=rec.get("id", ""),
+        job_title=fields.get("Job Title", "Untitled"),
+        company=fields.get("Company", "Unknown"),
+        location=fields.get("Location"),
+        score=float(fields.get("Matching Score", 0)),
+        score_breakdown=score_breakdown,
+        cv_link=cv_link,
+        cv_generated_at=cv_generated_at,
+        job_link=fields.get("Job Link", ""),
+        posted_date=fields.get("Job Date"),
+        description=fields.get("Job Description"),
+        match_reasons=reasons,
+        suggestions=suggestions,
+        application_status=fields.get("Application Status") or "saved",
+        application_notes=fields.get("Application Notes"),
+        applied_at=fields.get("Applied At"),
+    )
+
+
 @router.get("/results", response_model=JobResultsResponse)
 async def get_job_results(
     user: UserInfo = Depends(get_current_user),
     limit: int = 100,
     sort_by: str = "date"  # "date" or "score"
 ) -> JobResultsResponse:
-    """
-    Get the user's job search results with CV generation status.
-
-    Args:
-        user: Authenticated user
-        limit: Maximum number of results
-        sort_by: Sort order - "date" (default, most recent first) or "score" (highest first)
-
-    Returns:
-        List of job results with CV generation status
-    """
+    """Get the authenticated user's job search results."""
     try:
         joblist_manager = get_data_manager()
         history_manager = get_history_manager()
+        cv_dates = _cv_dates_by_url(history_manager.get_history_by_user(user.email))
+        records = joblist_manager.get_records_by_filter(_user_jobs_formula(str(user.email)))
+        items = [_job_result_from_record(rec, cv_dates) for rec in records[:limit]]
 
-        # Get CV history to map cv_link -> cv_generated_at
-        history_records = history_manager.get_history_by_user(user.email)
-
-        # Build a map of cv_pdf_url -> created_at
-        cv_dates = {}
-        for hr in history_records:
-            hf = hr.get("fields", {})
-            cv_url = hf.get("cv_pdf_url", "")
-            created_at = hf.get("created_at")
-            if cv_url and created_at:
-                cv_dates[cv_url] = created_at
-
-        records = joblist_manager.get_records_by_filter(f"{{User Email}} = '{user.email}'")
-
-        items = []
-        for rec in records[:limit]:
-            fields = rec.get("fields", {})
-
-            # Parse match reasons and suggestions
-            reasons_raw = fields.get("Match Reasons", "")
-            suggestions_raw = fields.get("Match Suggestions", "")
-
-            reasons = reasons_raw.split("\n") if reasons_raw else None
-            suggestions = suggestions_raw.split("\n") if suggestions_raw else None
-
-            cv_link = fields.get("CV Link") or None
-            cv_generated_at = None
-            if cv_link and cv_link in cv_dates:
-                try:
-                    cv_generated_at = datetime.fromisoformat(cv_dates[cv_link].replace('Z', '+00:00'))
-                except (ValueError, AttributeError):
-                    pass
-
-            # Build score breakdown (may be None for older records)
-            score_breakdown = None
-            ats_score = fields.get("Matching Score")
-            hr_score = fields.get("HR Score")
-            if ats_score is not None or hr_score is not None:
-                # Parse matched/missing keywords from comma-separated strings
-                matched_kw_raw = fields.get("Matched Keywords", "")
-                missing_kw_raw = fields.get("Missing Keywords", "")
-                matched_keywords = [kw.strip() for kw in matched_kw_raw.split(",") if kw.strip()] if matched_kw_raw else None
-                missing_keywords = [kw.strip() for kw in missing_kw_raw.split(",") if kw.strip()] if missing_kw_raw else None
-
-                score_breakdown = ScoreBreakdown(
-                    ats_score=float(ats_score) if ats_score else None,
-                    hr_score=float(hr_score) if hr_score else None,
-                    llm_score=float(fields.get("LLM Score")) if fields.get("LLM Score") else None,
-                    recommendation=fields.get("HR Recommendation"),
-                    matched_keywords=matched_keywords,
-                    missing_keywords=missing_keywords
-                )
-
-            items.append(JobResult(
-                id=rec.get("id", ""),
-                job_title=fields.get("Job Title", "Untitled"),
-                company=fields.get("Company", "Unknown"),
-                location=fields.get("Location"),
-                score=float(fields.get("Matching Score", 0)),
-                score_breakdown=score_breakdown,
-                cv_link=cv_link,
-                cv_generated_at=cv_generated_at,
-                job_link=fields.get("Job Link", ""),
-                posted_date=fields.get("Job Date"),
-                description=fields.get("Job Description"),
-                match_reasons=reasons,
-                suggestions=suggestions,
-                application_status=fields.get("Application Status") or "saved",
-                application_notes=fields.get("Application Notes"),
-                applied_at=fields.get("Applied At")
-            ))
-
-        # Sort based on user preference
         def parse_date(date_str):
-            """Parse date string to datetime"""
+            """Parse date string to datetime."""
             if not date_str:
                 return datetime.min
             try:
-                return datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+                return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
             except (ValueError, AttributeError):
                 try:
                     return datetime.strptime(date_str, "%Y-%m-%d")
@@ -761,23 +752,36 @@ async def get_job_results(
                     return datetime.min
 
         if sort_by == "score":
-            # Sort by score descending, then by date
-            items.sort(key=lambda x: (x.score, parse_date(x.posted_date)), reverse=True)
+            items.sort(key=lambda item: (item.score, parse_date(item.posted_date)), reverse=True)
         else:
-            # Default: sort by date descending, then by score
-            items.sort(key=lambda x: (parse_date(x.posted_date), x.score), reverse=True)
+            items.sort(key=lambda item: (parse_date(item.posted_date), item.score), reverse=True)
 
-        return JobResultsResponse(
-            items=items,
-            total=len(items)
-        )
-
+        return JobResultsResponse(items=items, total=len(items))
     except Exception as e:
         logger.error(f"Failed to get job results: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to get results: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Failed to get results: {str(e)}")
+
+
+@router.get("/results/{job_id}", response_model=JobResult)
+async def get_job_result(
+    job_id: str,
+    user: UserInfo = Depends(get_current_user),
+) -> JobResult:
+    """Get one matched job owned by the authenticated user."""
+    try:
+        manager = get_data_manager()
+        records = manager.get_records_by_filter(_user_jobs_formula(str(user.email)))
+        record = next((item for item in records if str(item.get("id", "")) == job_id), None)
+        if record is None:
+            raise HTTPException(status_code=404, detail="Job not found")
+
+        history = get_history_manager().get_history_by_user(user.email)
+        return _job_result_from_record(record, _cv_dates_by_url(history))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get job result: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to get result: {str(e)}")
 
 
 @router.patch("/results/{job_id}/application", response_model=JobResult)
@@ -801,11 +805,7 @@ async def update_application_status_result(
         if not updated:
             raise HTTPException(status_code=404, detail="Job not found")
 
-        results = await get_job_results(user=user, limit=500, sort_by="date")
-        for item in results.items:
-            if item.id == job_id:
-                return item
-        raise HTTPException(status_code=404, detail="Job not found")
+        return await get_job_result(job_id=job_id, user=user)
     except HTTPException:
         raise
     except Exception as e:

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -767,11 +767,10 @@ async def get_job_result(
     job_id: str,
     user: UserInfo = Depends(get_current_user),
 ) -> JobResult:
-    """Get one matched job owned by the authenticated user."""
+    """Get one owned job by its path-safe PostgreSQL UUID or Airtable record ID."""
     try:
         manager = get_data_manager()
-        records = manager.get_records_by_filter(_user_jobs_formula(str(user.email)))
-        record = next((item for item in records if str(item.get("id", "")) == job_id), None)
+        record = manager.get_job_result(job_id=job_id, user_email=str(user.email))
         if record is None:
             raise HTTPException(status_code=404, detail="Job not found")
 
@@ -790,7 +789,7 @@ async def update_application_status_result(
     update: ApplicationStatusUpdate,
     user: UserInfo = Depends(get_current_user)
 ) -> JobResult:
-    """Update application tracking state for a matched job."""
+    """Update tracking for a path-safe PostgreSQL UUID or Airtable record ID."""
     try:
         manager = get_data_manager()
         if not hasattr(manager, "update_application_status"):
@@ -805,7 +804,11 @@ async def update_application_status_result(
         if not updated:
             raise HTTPException(status_code=404, detail="Job not found")
 
-        return await get_job_result(job_id=job_id, user=user)
+        record = manager.get_job_result(job_id=job_id, user_email=str(user.email))
+        if record is None:
+            raise HTTPException(status_code=404, detail="Job not found")
+        history = get_history_manager().get_history_by_user(user.email)
+        return _job_result_from_record(record, _cv_dates_by_url(history))
     except HTTPException:
         raise
     except Exception as e:

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -654,12 +654,6 @@ async def get_user_search_tasks(
     ]
 
 
-def _user_jobs_formula(user_email: str) -> str:
-    """Build an Airtable-compatible, escaped user ownership filter."""
-    safe_email = user_email.replace("'", "\\'")
-    return f"{{User Email}} = '{safe_email}'"
-
-
 def _cv_dates_by_url(history_records: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Map generated CV URLs to their creation timestamps."""
     cv_dates = {}
@@ -693,7 +687,7 @@ def _job_result_from_record(rec: Dict[str, Any], cv_dates: Dict[str, Any]) -> Jo
                 pass
 
     score_breakdown = None
-    ats_score = fields.get("Matching Score")
+    ats_score = fields.get("ATS Score")
     hr_score = fields.get("HR Score")
     if ats_score is not None or hr_score is not None:
         matched_kw_raw = fields.get("Matched Keywords", "")
@@ -701,9 +695,13 @@ def _job_result_from_record(rec: Dict[str, Any], cv_dates: Dict[str, Any]) -> Jo
         matched_keywords = [kw.strip() for kw in matched_kw_raw.split(",") if kw.strip()] if matched_kw_raw else None
         missing_keywords = [kw.strip() for kw in missing_kw_raw.split(",") if kw.strip()] if missing_kw_raw else None
         score_breakdown = ScoreBreakdown(
-            ats_score=float(ats_score) if ats_score else None,
-            hr_score=float(hr_score) if hr_score else None,
-            llm_score=float(fields.get("LLM Score")) if fields.get("LLM Score") else None,
+            ats_score=float(ats_score) if ats_score is not None else None,
+            hr_score=float(hr_score) if hr_score is not None else None,
+            llm_score=(
+                float(fields.get("LLM Score"))
+                if fields.get("LLM Score") is not None
+                else None
+            ),
             recommendation=fields.get("HR Recommendation"),
             matched_keywords=matched_keywords,
             missing_keywords=missing_keywords,
@@ -740,7 +738,7 @@ async def get_job_results(
         joblist_manager = get_data_manager()
         history_manager = get_history_manager()
         cv_dates = _cv_dates_by_url(history_manager.get_history_by_user(user.email))
-        records = joblist_manager.get_records_by_filter(_user_jobs_formula(str(user.email)))
+        records = joblist_manager.get_jobs_by_user(str(user.email))
         items = [_job_result_from_record(rec, cv_dates) for rec in records[:limit]]
 
         def parse_date(date_str):

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -683,10 +683,14 @@ def _job_result_from_record(rec: Dict[str, Any], cv_dates: Dict[str, Any]) -> Jo
     cv_link = fields.get("CV Link") or None
     cv_generated_at = None
     if cv_link and cv_link in cv_dates:
-        try:
-            cv_generated_at = datetime.fromisoformat(cv_dates[cv_link].replace("Z", "+00:00"))
-        except (ValueError, AttributeError):
-            pass
+        created_at = cv_dates[cv_link]
+        if isinstance(created_at, datetime):
+            cv_generated_at = created_at
+        elif isinstance(created_at, str):
+            try:
+                cv_generated_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            except ValueError:
+                pass
 
     score_breakdown = None
     ats_score = fields.get("Matching Score")
@@ -780,7 +784,7 @@ async def get_job_result(
         raise
     except Exception as e:
         logger.error(f"Failed to get job result: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get result: {str(e)}")
+        raise HTTPException(status_code=503, detail="Job storage unavailable")
 
 
 @router.patch("/results/{job_id}/application", response_model=JobResult)
@@ -813,7 +817,7 @@ async def update_application_status_result(
         raise
     except Exception as e:
         logger.error(f"Failed to update application status: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to update application status: {str(e)}")
+        raise HTTPException(status_code=503, detail="Job storage unavailable")
 
 
 @router.get("/linkedin/status")

--- a/data_store/airtable_manager.py
+++ b/data_store/airtable_manager.py
@@ -232,6 +232,18 @@ class AirtableManager:
             self.logger.error("get_all_records error: %s", e)
             return []
 
+    def get_job_result(self, job_id: str, user_email: str) -> dict | None:
+        """Return a job only when the Airtable record is owned by the user."""
+        try:
+            record = self.table.get(job_id)
+        except Exception as e:
+            self.logger.info("Job result lookup failed for %s: %s", job_id, e)
+            return None
+
+        if record.get("fields", {}).get("User Email") != user_email:
+            return None
+        return record
+
     def get_records_by_filter(self, formula: str) -> list:
         """
         Run any Airtable formula, e.g. "{User Email} = 'joe@example.com'".

--- a/data_store/airtable_manager.py
+++ b/data_store/airtable_manager.py
@@ -35,16 +35,19 @@ class AirtableManager:
             # "created_at" is auto‐populated in Airtable as a "Created Time" field
         }
 
-    def job_exists(self, job_link):
-        # Use formula helper for safety
+    def job_exists(self, job_link, user_email: str | None = None):
+        # Scope deduplication to the current user when one is supplied.
         formula = EQ(Field("Job Link"), job_link)
+        if user_email is not None:
+            formula = AND(formula, EQ(Field("User Email"), user_email))
         records = self.table.all(formula=str(formula))
         return len(records) > 0
 
-    def get_existing_job_links(self):
-        """Get all existing job links to prevent duplicates"""
+    def get_existing_job_links(self, user_email: str | None = None):
+        """Get existing job links, optionally scoped to one user."""
         try:
-            records = self.table.all()
+            formula = str(EQ(Field("User Email"), user_email)) if user_email is not None else None
+            records = self.table.all(formula=formula) if formula else self.table.all()
             return {rec['fields']['Job Link'] for rec in records if 'Job Link' in rec['fields']}
         except Exception as e:
             self.logger.error(f"Failed to fetch existing jobs: {str(e)}")
@@ -82,12 +85,16 @@ class AirtableManager:
         llm_score=None,
         recommendation=None,
         matched_keywords=None,
-        missing_keywords=None
+        missing_keywords=None,
+        user_email: str | None = None,
     ):
-        """Update matching score, CV link, and score breakdown for existing job"""
+        """Update matching score, CV link, and score breakdown for an owned job."""
         try:
+            formula = EQ(Field("Job Link"), job_link)
+            if user_email is not None:
+                formula = AND(formula, EQ(Field("User Email"), user_email))
             record = self.table.first(
-                formula=str(EQ(Field("Job Link"), job_link)),
+                formula=str(formula),
                 fields=["Job Link"]
             )
             if record:
@@ -137,13 +144,13 @@ class AirtableManager:
                 continue
         return datetime.now().strftime('%Y-%m-%d')
 
-    def get_unprocessed_jobs(self):
-        """Get unprocessed jobs with filter formula"""
+    def get_unprocessed_jobs(self, user_email: str | None = None):
+        """Get unprocessed jobs, optionally scoped to one user."""
         try:
-            formula = AND(
-                EQ(Field("CV Link"), ""),
-                NE(Field("Job Description"),"")
-            )
+            filters = [EQ(Field("CV Link"), ""), NE(Field("Job Description"), "")]
+            if user_email is not None:
+                filters.append(EQ(Field("User Email"), user_email))
+            formula = AND(*filters)
             return self.table.all(
                 formula=str(formula),
                 fields=["Job Title", "Job Description", "Job Link", "Company"]
@@ -266,6 +273,14 @@ class AirtableManager:
         if application_status == "applied" and not record.get("fields", {}).get("Applied At"):
             fields["Applied At"] = datetime.now(timezone.utc).isoformat()
         return self.table.update(record["id"], fields)
+
+    def get_jobs_by_user(self, user_email: str) -> list:
+        """Return jobs owned by a user using Airtable's formula builder."""
+        try:
+            return self.table.all(formula=str(EQ(Field("User Email"), user_email)))
+        except Exception as e:
+            self.logger.error("get_jobs_by_user error: %s", e)
+            raise
 
     def get_records_by_filter(self, formula: str) -> list:
         """

--- a/data_store/airtable_manager.py
+++ b/data_store/airtable_manager.py
@@ -1,5 +1,7 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
+
+from requests import HTTPError
 
 from pyairtable.formulas import AND, EQ, NE, Field
 
@@ -236,13 +238,34 @@ class AirtableManager:
         """Return a job only when the Airtable record is owned by the user."""
         try:
             record = self.table.get(job_id)
-        except Exception as e:
-            self.logger.info("Job result lookup failed for %s: %s", job_id, e)
-            return None
+        except HTTPError as e:
+            if e.response is not None and e.response.status_code == 404:
+                return None
+            raise
 
         if record.get("fields", {}).get("User Email") != user_email:
             return None
         return record
+
+    def update_application_status(
+        self,
+        job_id: str,
+        user_email: str,
+        application_status: str,
+        application_notes: str | None = None,
+    ) -> dict | None:
+        """Update application tracking only when the record is exactly user-owned."""
+        record = self.get_job_result(job_id, user_email)
+        if record is None:
+            return None
+
+        fields = {
+            "Application Status": application_status,
+            "Application Notes": application_notes,
+        }
+        if application_status == "applied" and not record.get("fields", {}).get("Applied At"):
+            fields["Applied At"] = datetime.now(timezone.utc).isoformat()
+        return self.table.update(record["id"], fields)
 
     def get_records_by_filter(self, formula: str) -> list:
         """

--- a/data_store/postgres_manager.py
+++ b/data_store/postgres_manager.py
@@ -466,6 +466,58 @@ class PostgresManager:
             return []
 
 
+    def get_job_result(self, job_id: str, user_email: str) -> Optional[Dict]:
+        """Return one job owned by the user using parameterized SQL."""
+        try:
+            with self.get_cursor() as cursor:
+                cursor.execute("""
+                    SELECT id, user_email, job_title, job_description,
+                           job_date, job_link, company, location, matching_score,
+                           cv_link, match_reasons, match_suggestions,
+                           ats_score, hr_score, llm_score, hr_recommendation,
+                           matched_keywords, missing_keywords, application_status,
+                           application_notes, applied_at, created_at, updated_at
+                    FROM jobs
+                    WHERE id = %s AND user_email = %s
+                    LIMIT 1
+                """, (job_id, user_email))
+                row = cursor.fetchone()
+                return self._job_row_to_record(row) if row else None
+        except Exception as e:
+            self.logger.error(f"Job result lookup failed: {e}")
+            return None
+
+    @staticmethod
+    def _job_row_to_record(row: Dict) -> Dict:
+        """Convert a PostgreSQL job row to the shared Airtable-shaped record."""
+        return {
+            "id": str(row["id"]),
+            "fields": {
+                "User Email": row["user_email"],
+                "Job Title": row["job_title"],
+                "Job Description": row["job_description"],
+                "Job Date": str(row["job_date"]) if row["job_date"] else None,
+                "Job Link": row["job_link"],
+                "Company": row["company"],
+                "Location": row["location"],
+                "Matching Score": row["matching_score"],
+                "CV Link": row["cv_link"],
+                "Match Reasons": row["match_reasons"],
+                "Match Suggestions": row["match_suggestions"],
+                "ATS Score": row["ats_score"],
+                "HR Score": row["hr_score"],
+                "LLM Score": row["llm_score"],
+                "HR Recommendation": row["hr_recommendation"],
+                "Matched Keywords": row["matched_keywords"],
+                "Missing Keywords": row["missing_keywords"],
+                "Application Status": row.get("application_status") or "saved",
+                "Application Notes": row.get("application_notes"),
+                "Applied At": row.get("applied_at"),
+                "Created At": row["created_at"].isoformat() if row["created_at"] else None,
+                "Updated At": row["updated_at"].isoformat() if row["updated_at"] else None,
+            },
+        }
+
     # =========================================================================
     # AIRTABLE API COMPATIBILITY LAYER
     # =========================================================================
@@ -522,39 +574,7 @@ class PostgresManager:
 
                 rows = cursor.fetchall()
 
-                # Convert to Airtable format
-                records = []
-                for row in rows:
-                    record = {
-                        "id": str(row["id"]),
-                        "fields": {
-                            "User Email": row["user_email"],
-                            "Job Title": row["job_title"],
-                            "Job Description": row["job_description"],
-                            "Job Date": str(row["job_date"]) if row["job_date"] else None,
-                            "Job Link": row["job_link"],
-                            "Company": row["company"],
-                            "Location": row["location"],
-                            "Matching Score": row["matching_score"],
-                            "CV Link": row["cv_link"],
-                            "Match Reasons": row["match_reasons"],
-                            "Match Suggestions": row["match_suggestions"],
-                            "ATS Score": row["ats_score"],
-                            "HR Score": row["hr_score"],
-                            "LLM Score": row["llm_score"],
-                            "HR Recommendation": row["hr_recommendation"],
-                            "Matched Keywords": row["matched_keywords"],
-                            "Missing Keywords": row["missing_keywords"],
-                            "Application Status": row.get("application_status") or "saved",
-                            "Application Notes": row.get("application_notes"),
-                            "Applied At": row.get("applied_at"),
-                            "Created At": row["created_at"].isoformat() if row["created_at"] else None,
-                            "Updated At": row["updated_at"].isoformat() if row["updated_at"] else None,
-                        }
-                    }
-                    records.append(record)
-
-                return records
+                return [self._job_row_to_record(row) for row in rows]
 
         except Exception as e:
             self.logger.error(f"get_records_by_filter failed: {e}")

--- a/data_store/postgres_manager.py
+++ b/data_store/postgres_manager.py
@@ -97,53 +97,60 @@ class PostgresManager:
     # JOBS
     # =========================================================================
 
-    def job_exists(self, job_link: str) -> bool:
-        """Check if a job with this link already exists."""
+    def job_exists(self, job_link: str, user_email: Optional[str] = None) -> bool:
+        """Check for a duplicate URL, optionally within one user's jobs."""
         with self.get_cursor() as cursor:
-            cursor.execute(
-                "SELECT 1 FROM jobs WHERE job_link = %s LIMIT 1",
-                (job_link,)
-            )
+            if user_email is None:
+                cursor.execute("SELECT 1 FROM jobs WHERE job_link = %s LIMIT 1", (job_link,))
+            else:
+                cursor.execute(
+                    "SELECT 1 FROM jobs WHERE user_email = %s AND job_link = %s LIMIT 1",
+                    (user_email, job_link),
+                )
             return cursor.fetchone() is not None
 
-    def get_existing_job_links(self) -> set:
-        """Get all existing job links to prevent duplicates."""
-        try:
-            with self.get_cursor() as cursor:
+    def get_existing_job_links(self, user_email: Optional[str] = None) -> set:
+        """Get existing links, optionally scoped to one user."""
+        with self.get_cursor() as cursor:
+            if user_email is None:
                 cursor.execute("SELECT job_link FROM jobs WHERE job_link IS NOT NULL")
-                return {row["job_link"] for row in cursor.fetchall()}
-        except Exception as e:
-            self.logger.error(f"Failed to fetch existing jobs: {e}")
-            return set()
+            else:
+                cursor.execute(
+                    "SELECT job_link FROM jobs WHERE user_email = %s AND job_link IS NOT NULL",
+                    (user_email,),
+                )
+            return {row["job_link"] for row in cursor.fetchall()}
 
     def create_job_record(self, job_data: Dict, user_email: str = "system") -> Optional[Dict]:
-        """Create new job record."""
-        try:
-            with self.get_cursor() as cursor:
-                cursor.execute("""
-                    INSERT INTO jobs (
-                        user_email, job_title, job_description, job_date, job_link,
-                        company, location, matching_score, cv_link, application_status
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    RETURNING id, created_at
-                """, (
-                    user_email,
-                    job_data.get("Job Title"),
-                    job_data.get("Job Description"),
-                    self._format_date(job_data.get("Job Date")),
-                    job_data.get("Job Link"),
-                    job_data.get("Company"),
-                    job_data.get("Location"),
-                    job_data.get("score", 0),
-                    job_data.get("cv_url", ""),
-                    job_data.get("Application Status", "saved"),
-                ))
-                result = cursor.fetchone()
-                self.logger.info(f"Created job: {result['id']}")
-                return {"id": str(result["id"]), "fields": job_data}
-        except Exception as e:
-            self.logger.error(f"Create failed: {e}")
-            return None
+        """Create a job; duplicate URLs are allowed across different users."""
+        with self.get_cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO jobs (
+                    user_email, job_title, job_description, job_date, job_link,
+                    company, location, matching_score, cv_link, application_status
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (user_email, job_link) DO NOTHING
+                RETURNING id, created_at
+            """, (
+                user_email,
+                job_data.get("Job Title"),
+                job_data.get("Job Description"),
+                self._format_date(job_data.get("Job Date")),
+                job_data.get("Job Link"),
+                job_data.get("Company"),
+                job_data.get("Location"),
+                job_data.get("score", 0),
+                job_data.get("cv_url", ""),
+                job_data.get("Application Status", "saved"),
+            ))
+            result = cursor.fetchone()
+            if result is None:
+                self.logger.info("Job already exists for user: %s", user_email)
+                return None
+            self.logger.info(f"Created job: {result['id']}")
+            fields = dict(job_data)
+            fields["User Email"] = user_email
+            return {"id": str(result["id"]), "fields": fields}
 
     def update_cv_info(
         self,
@@ -157,12 +164,14 @@ class PostgresManager:
         llm_score: Optional[int] = None,
         recommendation: Optional[str] = None,
         matched_keywords: Optional[List[str]] = None,
-        missing_keywords: Optional[List[str]] = None
+        missing_keywords: Optional[List[str]] = None,
+        user_email: Optional[str] = None,
     ) -> Optional[Dict]:
         """Update matching score and CV link for existing job."""
         try:
             with self.get_cursor() as cursor:
-                cursor.execute("""
+                owner_clause = " AND user_email = %s" if user_email is not None else ""
+                cursor.execute(f"""
                     UPDATE jobs SET
                         matching_score = %s,
                         cv_link = %s,
@@ -176,7 +185,7 @@ class PostgresManager:
                         missing_keywords = %s,
                         application_status = CASE WHEN application_status = 'saved' THEN 'cv_generated' ELSE application_status END,
                         updated_at = NOW()
-                    WHERE job_link = %s
+                    WHERE job_link = %s{owner_clause}
                     RETURNING id
                 """, (
                     score,
@@ -190,6 +199,7 @@ class PostgresManager:
                     ", ".join(matched_keywords[:15]) if isinstance(matched_keywords, list) else matched_keywords,
                     ", ".join(missing_keywords[:15]) if isinstance(missing_keywords, list) else missing_keywords,
                     job_link,
+                    *([user_email] if user_email is not None else []),
                 ))
                 result = cursor.fetchone()
                 return {"id": str(result["id"])} if result else None
@@ -197,18 +207,20 @@ class PostgresManager:
             self.logger.error(f"Update failed: {e}")
             return None
 
-    def get_unprocessed_jobs(self) -> List[Dict]:
-        """Get jobs without CV links that have descriptions."""
+    def get_unprocessed_jobs(self, user_email: Optional[str] = None) -> List[Dict]:
+        """Get jobs without CV links, optionally scoped to one user."""
         try:
             with self.get_cursor() as cursor:
-                cursor.execute("""
+                owner_clause = " AND user_email = %s" if user_email is not None else ""
+                cursor.execute(f"""
                     SELECT id, job_title as "Job Title", job_description as "Job Description",
                            job_link as "Job Link", company as "Company"
                     FROM jobs
                     WHERE (cv_link IS NULL OR cv_link = '')
                       AND job_description IS NOT NULL AND job_description != ''
+                      {owner_clause}
                     ORDER BY created_at DESC
-                """)
+                """, (user_email,) if user_email is not None else ())
                 results = []
                 for row in cursor.fetchall():
                     fields = dict(row)
@@ -517,6 +529,22 @@ class PostgresManager:
     # =========================================================================
     # AIRTABLE API COMPATIBILITY LAYER
     # =========================================================================
+
+    def get_jobs_by_user(self, user_email: str) -> List[Dict]:
+        """Return jobs owned by a user without parsing an Airtable formula."""
+        with self.get_cursor() as cursor:
+            cursor.execute("""
+                SELECT id, user_email, job_title, job_description,
+                       job_date, job_link, company, location, matching_score,
+                       cv_link, match_reasons, match_suggestions,
+                       ats_score, hr_score, llm_score, hr_recommendation,
+                       matched_keywords, missing_keywords, application_status,
+                       application_notes, applied_at, created_at, updated_at
+                FROM jobs
+                WHERE user_email = %s
+                ORDER BY created_at DESC
+            """, (user_email,))
+            return [self._job_row_to_record(row) for row in cursor.fetchall()]
 
     def get_records_by_filter(self, formula: str) -> List[Dict]:
         """

--- a/data_store/postgres_manager.py
+++ b/data_store/postgres_manager.py
@@ -468,24 +468,20 @@ class PostgresManager:
 
     def get_job_result(self, job_id: str, user_email: str) -> Optional[Dict]:
         """Return one job owned by the user using parameterized SQL."""
-        try:
-            with self.get_cursor() as cursor:
-                cursor.execute("""
-                    SELECT id, user_email, job_title, job_description,
-                           job_date, job_link, company, location, matching_score,
-                           cv_link, match_reasons, match_suggestions,
-                           ats_score, hr_score, llm_score, hr_recommendation,
-                           matched_keywords, missing_keywords, application_status,
-                           application_notes, applied_at, created_at, updated_at
-                    FROM jobs
-                    WHERE id = %s AND user_email = %s
-                    LIMIT 1
-                """, (job_id, user_email))
-                row = cursor.fetchone()
-                return self._job_row_to_record(row) if row else None
-        except Exception as e:
-            self.logger.error(f"Job result lookup failed: {e}")
-            return None
+        with self.get_cursor() as cursor:
+            cursor.execute("""
+                SELECT id, user_email, job_title, job_description,
+                       job_date, job_link, company, location, matching_score,
+                       cv_link, match_reasons, match_suggestions,
+                       ats_score, hr_score, llm_score, hr_recommendation,
+                       matched_keywords, missing_keywords, application_status,
+                       application_notes, applied_at, created_at, updated_at
+                FROM jobs
+                WHERE id::text = %s AND user_email = %s
+                LIMIT 1
+            """, (job_id, user_email))
+            row = cursor.fetchone()
+            return self._job_row_to_record(row) if row else None
 
     @staticmethod
     def _job_row_to_record(row: Dict) -> Dict:
@@ -586,27 +582,27 @@ class PostgresManager:
         user_email: str,
         application_status: str,
         application_notes: Optional[str] = None,
+        *,
+        job_link: Optional[str] = None,
     ) -> Optional[Dict]:
-        """Update the user-facing application tracking state for a job."""
-        try:
-            with self.get_cursor() as cursor:
-                cursor.execute("""
-                    UPDATE jobs SET
-                        application_status = %s,
-                        application_notes = %s,
-                        applied_at = CASE
-                            WHEN %s = 'applied' AND applied_at IS NULL THEN NOW()
-                            ELSE applied_at
-                        END,
-                        updated_at = NOW()
-                    WHERE id = %s AND user_email = %s
-                    RETURNING id
-                """, (application_status, application_notes, application_status, job_id, user_email))
-                result = cursor.fetchone()
-                return {"id": str(result["id"])} if result else None
-        except Exception as e:
-            self.logger.error(f"Application status update failed: {e}")
-            return None
+        """Update application tracking for an owned ID, or job link during dual-write."""
+        lookup_column = "job_link" if job_link else "id::text"
+        lookup_value = job_link or job_id
+        with self.get_cursor() as cursor:
+            cursor.execute(f"""
+                UPDATE jobs SET
+                    application_status = %s,
+                    application_notes = %s,
+                    applied_at = CASE
+                        WHEN %s = 'applied' AND applied_at IS NULL THEN NOW()
+                        ELSE applied_at
+                    END,
+                    updated_at = NOW()
+                WHERE {lookup_column} = %s AND user_email = %s
+                RETURNING id
+            """, (application_status, application_notes, application_status, lookup_value, user_email))
+            result = cursor.fetchone()
+            return {"id": str(result["id"])} if result else None
 
     # =========================================================================
     # UTILITIES

--- a/data_store/storage_factory.py
+++ b/data_store/storage_factory.py
@@ -67,6 +67,9 @@ class DualWriteDataManager:
     def get_unprocessed_jobs(self) -> List[Dict]:
         return self.airtable.get_unprocessed_jobs()
     
+    def get_job_result(self, job_id: str, user_email: str) -> Optional[Dict]:
+        return self.airtable.get_job_result(job_id, user_email)
+
     def get_history_record(self, record_id: str) -> Optional[Dict]:
         return self.airtable.get_history_record(record_id)
     

--- a/data_store/storage_factory.py
+++ b/data_store/storage_factory.py
@@ -110,6 +110,32 @@ class DualWriteDataManager:
             self.logger.warning(f"Postgres shadow write failed (update_cv_info): {e}")
         
         return result
+
+    def update_application_status(
+        self,
+        job_id: str,
+        user_email: str,
+        application_status: str,
+        application_notes: Optional[str] = None,
+    ) -> Optional[Dict]:
+        result = self.airtable.update_application_status(
+            job_id, user_email, application_status, application_notes
+        )
+        if result is None:
+            return None
+
+        try:
+            self.postgres.update_application_status(
+                job_id,
+                user_email,
+                application_status,
+                application_notes,
+                job_link=result.get("fields", {}).get("Job Link"),
+            )
+        except Exception as e:
+            self.logger.warning(f"Postgres shadow write failed (update_application_status): {e}")
+
+        return result
     
     def create_history_record(self, data: Dict) -> Optional[str]:
         result = self.airtable.create_history_record(data)

--- a/data_store/storage_factory.py
+++ b/data_store/storage_factory.py
@@ -40,6 +40,10 @@ if STORAGE_BACKEND not in ("airtable", "postgres", "dual"):
 # DATA MANAGER (Jobs, History, User Config, Notifications)
 # =============================================================================
 
+class ShadowWriteError(RuntimeError):
+    """Raised when a required PostgreSQL shadow write is not persisted."""
+
+
 class DualWriteDataManager:
     """
     Dual-write manager that writes to both Airtable and PostgreSQL.
@@ -58,14 +62,17 @@ class DualWriteDataManager:
     # READ OPERATIONS (Airtable primary)
     # =========================================================================
     
-    def job_exists(self, job_link: str) -> bool:
-        return self.airtable.job_exists(job_link)
+    def job_exists(self, job_link: str, user_email: Optional[str] = None) -> bool:
+        return self.airtable.job_exists(job_link, user_email=user_email)
     
-    def get_existing_job_links(self) -> set:
-        return self.airtable.get_existing_job_links()
+    def get_existing_job_links(self, user_email: Optional[str] = None) -> set:
+        return self.airtable.get_existing_job_links(user_email=user_email)
+
+    def get_jobs_by_user(self, user_email: str) -> List[Dict]:
+        return self.airtable.get_jobs_by_user(user_email)
     
-    def get_unprocessed_jobs(self) -> List[Dict]:
-        return self.airtable.get_unprocessed_jobs()
+    def get_unprocessed_jobs(self, user_email: Optional[str] = None) -> List[Dict]:
+        return self.airtable.get_unprocessed_jobs(user_email=user_email)
     
     def get_job_result(self, job_id: str, user_email: str) -> Optional[Dict]:
         return self.airtable.get_job_result(job_id, user_email)
@@ -93,22 +100,34 @@ class DualWriteDataManager:
         # Primary: Airtable
         result = self.airtable.create_job_record(job_data, user_email)
         
-        # Shadow: PostgreSQL (fire and forget, log errors)
+        if result is None:
+            return None
         try:
-            self.postgres.create_job_record(job_data, user_email)
+            shadow_result = self.postgres.create_job_record(job_data, user_email)
         except Exception as e:
-            self.logger.warning(f"Postgres shadow write failed (create_job): {e}")
-        
+            self.logger.warning("Postgres shadow write failed (create_job): %s", e)
+            raise ShadowWriteError("Postgres shadow job create failed") from e
+        if shadow_result is None:
+            self.logger.warning("Postgres shadow write missed job create for user_email=%s", user_email)
+            raise ShadowWriteError("Postgres shadow job create did not persist")
         return result
     
     def update_cv_info(self, job_link: str, score: int, cv_url: str, **kwargs) -> Optional[Dict]:
         result = self.airtable.update_cv_info(job_link, score, cv_url, **kwargs)
-        
+        if result is None:
+            return None
+
         try:
-            self.postgres.update_cv_info(job_link, score, cv_url, **kwargs)
+            shadow_result = self.postgres.update_cv_info(job_link, score, cv_url, **kwargs)
         except Exception as e:
-            self.logger.warning(f"Postgres shadow write failed (update_cv_info): {e}")
-        
+            self.logger.warning("Postgres shadow write failed (update_cv_info): %s", e)
+            raise ShadowWriteError("Postgres shadow CV update failed") from e
+        if shadow_result is None:
+            self.logger.warning(
+                "Postgres shadow write missed CV update job_link=%s", job_link
+            )
+            raise ShadowWriteError("Postgres shadow CV update did not persist")
+
         return result
 
     def update_application_status(
@@ -125,7 +144,7 @@ class DualWriteDataManager:
             return None
 
         try:
-            self.postgres.update_application_status(
+            shadow_result = self.postgres.update_application_status(
                 job_id,
                 user_email,
                 application_status,
@@ -133,7 +152,15 @@ class DualWriteDataManager:
                 job_link=result.get("fields", {}).get("Job Link"),
             )
         except Exception as e:
-            self.logger.warning(f"Postgres shadow write failed (update_application_status): {e}")
+            self.logger.warning("Postgres shadow write failed (update_application_status): %s", e)
+            raise ShadowWriteError("Postgres shadow application update failed") from e
+        if shadow_result is None:
+            self.logger.warning(
+                "Postgres shadow write missed application job_id=%s user_email=%s",
+                job_id,
+                user_email,
+            )
+            raise ShadowWriteError("Postgres shadow application update did not persist")
 
         return result
     

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -27,9 +29,11 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
+        "jsdom": "^26.1.0",
         "postcss": "^8.5.1",
         "tailwindcss": "^3.4.17",
-        "vite": "^6.0.7"
+        "vite": "^6.0.7",
+        "vitest": "^3.2.7"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -45,6 +49,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@azure/msal-browser": {
       "version": "4.27.0",
@@ -93,6 +118,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -334,6 +360,123 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2032,6 +2175,7 @@
       "version": "2.4.25",
       "resolved": "https://registry.npmjs.org/@heroui/theme/-/theme-2.4.25.tgz",
       "integrity": "sha512-nTptYhO1V9rMoh9SJDnMfaSmFuoXvbem1UuwgHcraRtqy/TIVBPqv26JEGzSoUCL194TDGOJpqrpMuab/PdXcw==",
+      "peer": true,
       "dependencies": {
         "@heroui/shared-utils": "2.1.12",
         "color": "^4.2.3",
@@ -2113,8 +2257,7 @@
     "node_modules/@heroui/react/node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "peer": true
+      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="
     },
     "node_modules/@heroui/shared-icons": {
       "version": "2.1.10",
@@ -2134,6 +2277,7 @@
       "version": "2.4.25",
       "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.25.tgz",
       "integrity": "sha512-F6UUoGTQ+Qas5wYkCzLjXE7u74Z9ygO0u0+dkTW7zCaY7ds65CcmvZ/ahKz2ES3Tk6TNks1MJSyaQ9rFLs8AqA==",
+      "peer": true,
       "dependencies": {
         "@heroui/react-utils": "2.1.14",
         "@heroui/system-rsc": "2.3.21",
@@ -4181,6 +4325,76 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4222,6 +4436,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4245,6 +4477,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4255,6 +4488,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4279,11 +4513,127 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4300,6 +4650,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4314,6 +4674,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -4358,6 +4728,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -4490,6 +4870,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4620,6 +5010,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4632,6 +5023,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -4719,6 +5120,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4733,6 +5151,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -4881,11 +5309,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4960,6 +5416,16 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5008,6 +5474,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -5030,6 +5506,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5049,6 +5532,19 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -5162,6 +5658,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -5286,6 +5789,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5471,6 +5975,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5478,6 +5992,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5630,6 +6154,7 @@
       "version": "12.23.26",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.26.tgz",
       "integrity": "sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA==",
+      "peer": true,
       "dependencies": {
         "motion-dom": "^12.23.23",
         "motion-utils": "^12.23.6",
@@ -5909,6 +6434,60 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -6222,6 +6801,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6391,6 +6977,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6410,6 +6997,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -6539,6 +7167,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6554,6 +7189,26 @@
       "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6662,6 +7317,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6847,6 +7509,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6869,6 +7544,23 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6929,6 +7621,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7088,6 +7781,41 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7131,6 +7859,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7142,6 +7871,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7354,6 +8084,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7426,6 +8163,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7597,6 +8354,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -7612,6 +8376,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7731,6 +8509,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -7775,6 +8573,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -7806,6 +8611,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7876,6 +8682,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7911,12 +8731,63 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -7927,6 +8798,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -8142,6 +9039,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8211,6 +9109,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -8233,11 +9154,159 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -8340,6 +9409,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8348,6 +9434,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test src/**/*.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "test": "node --test src/**/*.test.js",
+    "test": "node --test src/**/*.test.js && vitest run src/pages/ApplicationWorkspace.test.jsx",
+    "test:component": "vitest run src/pages/ApplicationWorkspace.test.jsx",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -24,6 +25,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
@@ -33,8 +36,10 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
+    "jsdom": "^26.1.0",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^3.2.7"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import UploadCV from './pages/UploadCV'
 import Preferences from './pages/Preferences'
 import GenerateCV from './pages/GenerateCV'
 import History from './pages/History'
+import ApplicationWorkspace from './pages/ApplicationWorkspace'
 import Profile from './pages/Profile'
 import CVLibrary from './pages/CVLibrary'
 import CVAnalytics from './pages/CVAnalytics'
@@ -104,6 +105,7 @@ function App() {
         <Route path="/preferences" element={<Preferences />} />
         <Route path="/generate" element={<GenerateCV />} />
         <Route path="/history" element={<History />} />
+        <Route path="/applications/:jobId" element={<ApplicationWorkspace />} />
         <Route path="/cv-library" element={<CVLibrary />} />
         <Route path="/cv-analytics" element={<CVAnalytics />} />
         <Route path="/profile" element={<Profile />} />

--- a/frontend/src/pages/ApplicationWorkspace.jsx
+++ b/frontend/src/pages/ApplicationWorkspace.jsx
@@ -1,0 +1,337 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  ArrowLeft,
+  Bot,
+  Briefcase,
+  Building2,
+  Check,
+  CheckCircle2,
+  ClipboardCheck,
+  ExternalLink,
+  FileText,
+  Loader2,
+  MapPin,
+  SearchCheck,
+  Target,
+  Users,
+} from 'lucide-react'
+import { jobService } from '../services/api'
+import { trackApplicationStatusUpdate, trackJobDetailsOpen } from '../services/telemetry'
+import {
+  formatFitScore,
+  getJobSource,
+  getSafeExternalUrl,
+  getWorkflowProgress,
+} from '../utils/applicationWorkspace'
+
+const STATUS_OPTIONS = [
+  { value: 'saved', label: 'Saved' },
+  { value: 'cv_generated', label: 'CV generated' },
+  { value: 'applied', label: 'Applied' },
+  { value: 'interviewing', label: 'Interviewing' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'offer', label: 'Offer' },
+  { value: 'archived', label: 'Archived' },
+]
+
+function ScoreCard({ icon: Icon, label, value, colour }) {
+  return (
+    <div className="card-elevated p-4">
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <Icon className={`w-4 h-4 ${colour}`} aria-hidden="true" />
+        {label}
+      </div>
+      <p className="mt-2 text-xl font-semibold text-text-primary">{value}</p>
+    </div>
+  )
+}
+
+function StageCard({ number, title, description, complete, children }) {
+  return (
+    <section className="card-elevated p-5" aria-labelledby={`stage-${number}`}>
+      <div className="flex items-start gap-3">
+        <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${complete ? 'bg-emerald-500/20 text-emerald-400' : 'bg-accent-500/20 text-accent-400'}`}>
+          {complete ? <Check className="w-4 h-4" aria-hidden="true" /> : number}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 id={`stage-${number}`} className="font-semibold text-text-primary">{title}</h2>
+          <p className="mt-1 text-sm text-text-secondary">{description}</p>
+          {children && <div className="mt-4">{children}</div>}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default function ApplicationWorkspace() {
+  const { jobId } = useParams()
+  const navigate = useNavigate()
+  const [job, setJob] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(null)
+  const [status, setStatus] = useState('saved')
+  const [notes, setNotes] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saveMessage, setSaveMessage] = useState(null)
+  const [trackingUnavailable, setTrackingUnavailable] = useState(false)
+
+  useEffect(() => {
+    let active = true
+
+    const loadJob = async () => {
+      setLoading(true)
+      setLoadError(null)
+      try {
+        const jobs = await jobService.getMatchedJobs('date')
+        const selectedJob = jobs.find((item) => String(item.id) === String(jobId))
+        if (!active) return
+
+        setJob(selectedJob || null)
+        if (selectedJob) {
+          setStatus(selectedJob.application_status || 'saved')
+          setNotes(selectedJob.application_notes || '')
+          trackJobDetailsOpen(String(selectedJob.id), selectedJob.job_title)
+        }
+      } catch (error) {
+        if (active) setLoadError(error.userMessage || error.message || 'Failed to load this application')
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    loadJob()
+    return () => {
+      active = false
+    }
+  }, [jobId])
+
+  const handleTailorCV = () => {
+    navigate('/generate', {
+      state: {
+        jobTitle: job.job_title,
+        jobDescription: job.description,
+        jobLink: job.job_link,
+        jobId: job.id,
+      },
+    })
+  }
+
+  const handleSaveTracking = async () => {
+    setSaving(true)
+    setSaveMessage(null)
+    try {
+      const previousStatus = job.application_status || 'saved'
+      const updatedJob = await jobService.updateApplicationStatus(job.id, status, notes)
+      setJob(updatedJob)
+      setStatus(updatedJob.application_status || status)
+      setNotes(updatedJob.application_notes || '')
+      if (previousStatus !== status) trackApplicationStatusUpdate(String(job.id), status)
+      setSaveMessage({ type: 'success', text: 'Application tracking saved.' })
+    } catch (error) {
+      if (error.status === 501) setTrackingUnavailable(true)
+      setSaveMessage({
+        type: 'error',
+        text: error.status === 501
+          ? 'Application tracking is unavailable for the configured storage backend.'
+          : error.userMessage || error.message || 'Failed to save application tracking.',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-[50vh] flex items-center justify-center" role="status">
+        <Loader2 className="w-7 h-7 text-accent-400 animate-spin" aria-hidden="true" />
+        <span className="sr-only">Loading application workspace</span>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="max-w-3xl mx-auto space-y-4">
+        <button type="button" onClick={() => navigate('/history')} className="btn-ghost">
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to job matches
+        </button>
+        <div className="card border-red-500/30" role="alert">
+          <h1 className="text-xl font-semibold text-text-primary">Workspace unavailable</h1>
+          <p className="mt-2 text-red-400">{loadError}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!job) {
+    return (
+      <div className="max-w-3xl mx-auto space-y-4">
+        <button type="button" onClick={() => navigate('/history')} className="btn-ghost">
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to job matches
+        </button>
+        <div className="card text-center py-12">
+          <Briefcase className="w-12 h-12 text-text-muted mx-auto" aria-hidden="true" />
+          <h1 className="mt-4 text-xl font-semibold text-text-primary">Application not found</h1>
+          <p className="mt-2 text-text-secondary">This job is unavailable or is not in your matched jobs.</p>
+        </div>
+      </div>
+    )
+  }
+
+  const applyUrl = getSafeExternalUrl(job.job_link)
+  const progress = getWorkflowProgress({ ...job, application_status: status })
+  const breakdown = job.score_breakdown
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      <button type="button" onClick={() => navigate('/history')} className="btn-ghost -ml-4">
+        <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to job matches
+      </button>
+
+      <header className="card">
+        <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-5">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-sm text-text-muted">
+              <Building2 className="w-4 h-4" aria-hidden="true" />
+              <span>{job.company || 'Company unavailable'}</span>
+              <span aria-hidden="true">·</span>
+              <span>{getJobSource(job.job_link)}</span>
+            </div>
+            <h1 className="mt-2 text-2xl font-bold text-text-primary">{job.job_title || 'Untitled role'}</h1>
+            {job.location && (
+              <p className="mt-2 flex items-center gap-1.5 text-sm text-text-secondary">
+                <MapPin className="w-4 h-4" aria-hidden="true" /> {job.location}
+              </p>
+            )}
+          </div>
+          <div className="badge-primary text-sm self-start">
+            {formatFitScore(job.score)} match
+          </div>
+        </div>
+      </header>
+
+      <section aria-labelledby="fit-heading" className="space-y-4">
+        <div>
+          <h2 id="fit-heading" className="text-lg font-semibold text-text-primary">Fit analysis</h2>
+          <p className="text-sm text-text-secondary">Existing match signals for this role.</p>
+        </div>
+        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <ScoreCard icon={SearchCheck} label="Overall match" value={formatFitScore(job.score)} colour="text-accent-400" />
+          <ScoreCard icon={Target} label="ATS score" value={formatFitScore(breakdown?.ats_score, 100)} colour="text-sky-400" />
+          <ScoreCard icon={Users} label="HR score" value={formatFitScore(breakdown?.hr_score, 100)} colour="text-emerald-400" />
+          <ScoreCard icon={Bot} label="AI score" value={formatFitScore(breakdown?.llm_score)} colour="text-purple-400" />
+        </div>
+
+        {(job.match_reasons?.length > 0 || job.suggestions?.length > 0) ? (
+          <div className="grid md:grid-cols-2 gap-4">
+            {job.match_reasons?.length > 0 && (
+              <div className="card-elevated p-5">
+                <h3 className="font-medium text-text-primary">Why this matched</h3>
+                <ul className="mt-3 space-y-2 text-sm text-text-secondary list-disc pl-5">
+                  {job.match_reasons.map((reason, index) => <li key={`${reason}-${index}`}>{reason}</li>)}
+                </ul>
+              </div>
+            )}
+            {job.suggestions?.length > 0 && (
+              <div className="card-elevated p-5">
+                <h3 className="font-medium text-text-primary">How to improve fit</h3>
+                <ul className="mt-3 space-y-2 text-sm text-text-secondary list-disc pl-5">
+                  {job.suggestions.map((suggestion, index) => <li key={`${suggestion}-${index}`}>{suggestion}</li>)}
+                </ul>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="card-elevated p-5 text-sm text-text-muted">Match explanations are unavailable for this job.</div>
+        )}
+      </section>
+
+      <section aria-labelledby="workflow-heading" className="space-y-4">
+        <div>
+          <h2 id="workflow-heading" className="text-lg font-semibold text-text-primary">Application workflow</h2>
+          <p className="text-sm text-text-secondary">Move from analysis to a tracked application.</p>
+        </div>
+        <div className="grid lg:grid-cols-2 gap-4">
+          <StageCard number="1" title="Analyse" description="Review the existing fit scores and match explanations." complete={progress.analyse} />
+
+          <StageCard number="2" title="Tailor CV" description={job.cv_link ? 'A tailored CV is available. You can return to the generator to refine it.' : 'Open the existing CV generator with this job context.'} complete={progress.tailor}>
+            <button type="button" onClick={handleTailorCV} className="btn-secondary w-full sm:w-auto">
+              <FileText className="w-4 h-4" aria-hidden="true" />
+              {job.cv_link ? 'Refine tailored CV' : 'Tailor CV'}
+            </button>
+          </StageCard>
+
+          <StageCard number="3" title="Apply" description="Open the original job posting in a new tab." complete={progress.apply}>
+            {applyUrl ? (
+              <a href={applyUrl} target="_blank" rel="noopener noreferrer" className="btn-primary w-full sm:w-auto">
+                <ExternalLink className="w-4 h-4" aria-hidden="true" /> Apply externally
+              </a>
+            ) : (
+              <p className="text-sm text-amber-400">A safe external application URL is unavailable.</p>
+            )}
+          </StageCard>
+
+          <StageCard number="4" title="Track" description="Save the current application stage and private notes." complete={progress.track}>
+            <div className="space-y-4">
+              {trackingUnavailable && (
+                <div className="p-3 rounded-xl bg-amber-500/10 border border-amber-500/20 text-sm text-amber-400">
+                  Tracking updates are not supported by the configured storage backend.
+                </div>
+              )}
+              <div>
+                <label htmlFor="application-status" className="input-label">Application status</label>
+                <select
+                  id="application-status"
+                  value={status}
+                  onChange={(event) => setStatus(event.target.value)}
+                  className="input"
+                  disabled={saving || trackingUnavailable}
+                >
+                  {STATUS_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <div className="flex items-center justify-between gap-3">
+                  <label htmlFor="application-notes" className="input-label">Notes</label>
+                  <span className="text-xs text-text-muted">{notes.length}/2000</span>
+                </div>
+                <textarea
+                  id="application-notes"
+                  value={notes}
+                  onChange={(event) => setNotes(event.target.value)}
+                  className="input min-h-32 resize-y"
+                  maxLength={2000}
+                  placeholder="Add interview details, follow-up dates, or next steps..."
+                  disabled={saving || trackingUnavailable}
+                />
+              </div>
+              <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+                <button
+                  type="button"
+                  onClick={handleSaveTracking}
+                  className="btn-primary"
+                  disabled={saving || trackingUnavailable}
+                >
+                  {saving ? <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" /> : <ClipboardCheck className="w-4 h-4" aria-hidden="true" />}
+                  {saving ? 'Saving...' : 'Save tracking'}
+                </button>
+                {saveMessage && (
+                  <p
+                    role={saveMessage.type === 'error' ? 'alert' : 'status'}
+                    className={`text-sm ${saveMessage.type === 'error' ? 'text-red-400' : 'text-emerald-400'}`}
+                  >
+                    {saveMessage.type === 'success' && <CheckCircle2 className="inline w-4 h-4 mr-1" aria-hidden="true" />}
+                    {saveMessage.text}
+                  </p>
+                )}
+              </div>
+            </div>
+          </StageCard>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/ApplicationWorkspace.jsx
+++ b/frontend/src/pages/ApplicationWorkspace.jsx
@@ -83,18 +83,21 @@ export default function ApplicationWorkspace() {
       setLoading(true)
       setLoadError(null)
       try {
-        const jobs = await jobService.getMatchedJobs('date')
-        const selectedJob = jobs.find((item) => String(item.id) === String(jobId))
+        const selectedJob = await jobService.getResult(jobId)
         if (!active) return
 
-        setJob(selectedJob || null)
+        setJob(selectedJob)
         if (selectedJob) {
           setStatus(selectedJob.application_status || 'saved')
           setNotes(selectedJob.application_notes || '')
           trackJobDetailsOpen(String(selectedJob.id), selectedJob.job_title)
         }
       } catch (error) {
-        if (active) setLoadError(error.userMessage || error.message || 'Failed to load this application')
+        if (active && error.status === 404) {
+          setJob(null)
+        } else if (active) {
+          setLoadError(error.userMessage || error.message || 'Failed to load this application')
+        }
       } finally {
         if (active) setLoading(false)
       }

--- a/frontend/src/pages/ApplicationWorkspace.test.jsx
+++ b/frontend/src/pages/ApplicationWorkspace.test.jsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import ApplicationWorkspace from './ApplicationWorkspace'
+import { jobService } from '../services/api'
+
+vi.mock('../services/api', () => ({
+  jobService: {
+    getResult: vi.fn(),
+    updateApplicationStatus: vi.fn(),
+  },
+}))
+
+vi.mock('../services/telemetry', () => ({
+  trackApplicationStatusUpdate: vi.fn(),
+  trackJobDetailsOpen: vi.fn(),
+}))
+
+const baseJob = {
+  id: 'recA1b2C3d4E5f6G7',
+  job_title: 'Platform Engineer',
+  company: 'Example Co',
+  location: 'Melbourne',
+  score: 8.7,
+  score_breakdown: null,
+  job_link: 'https://jobs.example.com/123',
+  description: 'Build reliable systems',
+  match_reasons: [],
+  suggestions: [],
+  cv_link: null,
+  application_status: 'saved',
+  application_notes: null,
+}
+
+function renderWorkspace() {
+  return render(
+    <MemoryRouter initialEntries={['/applications/recA1b2C3d4E5f6G7']}>
+      <Routes>
+        <Route path="/applications/:jobId" element={<ApplicationWorkspace />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ApplicationWorkspace', () => {
+  it('shows the not-found message for a 404', async () => {
+    jobService.getResult.mockRejectedValue({ status: 404 })
+
+    renderWorkspace()
+
+    expect(await screen.findByRole('heading', { name: 'Application not found' })).toBeTruthy()
+    expect(screen.getByText('This job is unavailable or is not in your matched jobs.')).toBeTruthy()
+  })
+
+  it('shows a generic load error', async () => {
+    jobService.getResult.mockRejectedValue({ userMessage: 'The workspace could not be loaded.' })
+
+    renderWorkspace()
+
+    expect(await screen.findByRole('heading', { name: 'Workspace unavailable' })).toBeTruthy()
+    expect(screen.getByRole('alert').textContent).toContain('The workspace could not be loaded.')
+  })
+
+  it('initializes tracking fields and applies the saved response', async () => {
+    const user = userEvent.setup()
+    jobService.getResult.mockResolvedValue({
+      ...baseJob,
+      application_status: 'interviewing',
+      application_notes: 'Phone screen booked',
+    })
+    jobService.updateApplicationStatus.mockResolvedValue({
+      ...baseJob,
+      application_status: 'applied',
+      application_notes: 'Submitted today',
+    })
+
+    renderWorkspace()
+
+    const status = await screen.findByLabelText('Application status')
+    const notes = screen.getByLabelText('Notes')
+    expect(status.value).toBe('interviewing')
+    expect(notes.value).toBe('Phone screen booked')
+
+    fireEvent.change(status, { target: { value: 'applied' } })
+    await user.clear(notes)
+    await user.type(notes, 'Sent via company portal')
+    await user.click(screen.getByRole('button', { name: 'Save tracking' }))
+
+    await waitFor(() => {
+      expect(jobService.updateApplicationStatus).toHaveBeenCalledWith(
+        baseJob.id,
+        'applied',
+        'Sent via company portal',
+      )
+    })
+    expect(await screen.findByText('Application tracking saved.')).toBeTruthy()
+    expect(status.value).toBe('applied')
+    expect(notes.value).toBe('Submitted today')
+  })
+
+  it('disables tracking controls after a 501 response', async () => {
+    const user = userEvent.setup()
+    jobService.getResult.mockResolvedValue(baseJob)
+    jobService.updateApplicationStatus.mockRejectedValue({ status: 501 })
+
+    renderWorkspace()
+
+    const saveButton = await screen.findByRole('button', { name: 'Save tracking' })
+    await user.click(saveButton)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Application tracking is unavailable')
+    expect(screen.getByText('Application tracking is unavailable for the configured storage backend.')).toBeTruthy()
+    expect(screen.getByLabelText('Application status').disabled).toBe(true)
+    expect(screen.getByLabelText('Notes').disabled).toBe(true)
+    expect(saveButton.disabled).toBe(true)
+  })
+})

--- a/frontend/src/pages/ApplicationWorkspace.test.jsx
+++ b/frontend/src/pages/ApplicationWorkspace.test.jsx
@@ -24,7 +24,7 @@ const baseJob = {
   company: 'Example Co',
   location: 'Melbourne',
   score: 8.7,
-  score_breakdown: null,
+  score_breakdown: { ats_score: 92, hr_score: 81, llm_score: 7.4 },
   job_link: 'https://jobs.example.com/123',
   description: 'Build reliable systems',
   match_reasons: [],
@@ -69,6 +69,15 @@ describe('ApplicationWorkspace', () => {
 
     expect(await screen.findByRole('heading', { name: 'Workspace unavailable' })).toBeTruthy()
     expect(screen.getByRole('alert').textContent).toContain('The workspace could not be loaded.')
+  })
+
+  it('renders distinct overall and ATS scores', async () => {
+    jobService.getResult.mockResolvedValue(baseJob)
+
+    renderWorkspace()
+
+    expect(await screen.findByText('87%')).toBeTruthy()
+    expect(screen.getByText('92%')).toBeTruthy()
   })
 
   it('initializes tracking fields and applies the saved response', async () => {

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -356,7 +356,7 @@ export default function History() {
                   {/* Actions */}
                   <div className="flex items-center gap-2 flex-shrink-0">
                     <button
-                      onClick={() => navigate(`/applications/${job.id}`)}
+                      onClick={() => navigate(`/applications/${encodeURIComponent(job.id)}`)}
                       className="btn-secondary text-sm py-1.5 px-3"
                       title="Open application workspace"
                     >

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -22,6 +22,7 @@ import {
   ClipboardCheck,
 } from 'lucide-react'
 import { jobService } from '../services/api'
+import { getSafeExternalUrl } from '../utils/applicationWorkspace'
 
 export default function History() {
   const navigate = useNavigate()
@@ -80,7 +81,7 @@ export default function History() {
       item.id === job.id ? { ...item, application_status: applicationStatus } : item
     ))
     try {
-      await jobService.updateApplicationStatus(job.id, applicationStatus)
+      await jobService.updateApplicationStatus(job.id, applicationStatus, job.application_notes)
     } catch (err) {
       console.error('Failed to update application status:', err)
       setError(err.message || 'Failed to update application status')
@@ -354,6 +355,14 @@ export default function History() {
 
                   {/* Actions */}
                   <div className="flex items-center gap-2 flex-shrink-0">
+                    <button
+                      onClick={() => navigate(`/applications/${job.id}`)}
+                      className="btn-secondary text-sm py-1.5 px-3"
+                      title="Open application workspace"
+                    >
+                      <ClipboardCheck className="w-4 h-4" />
+                      Workspace
+                    </button>
                     {job.cv_link ? (
                       <>
                         <a
@@ -385,16 +394,18 @@ export default function History() {
                         Generate CV
                       </button>
                     )}
-                    <a
-                      href={job.job_link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn-icon text-text-muted hover:text-accent-400"
-                      aria-label="View job posting"
-                      title="View job posting"
-                    >
-                      <ExternalLink className="w-5 h-5" />
-                    </a>
+                    {getSafeExternalUrl(job.job_link) && (
+                      <a
+                        href={getSafeExternalUrl(job.job_link)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn-icon text-text-muted hover:text-accent-400"
+                        aria-label="View job posting"
+                        title="View job posting"
+                      >
+                        <ExternalLink className="w-5 h-5" />
+                      </a>
+                    )}
                   </div>
                 </div>
 

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -93,10 +93,13 @@ export default function History() {
 
   const handleDownload = async (cvLink, jobTitle) => {
     try {
+      const safeCvLink = getSafeExternalUrl(cvLink)
+      if (!safeCvLink) throw new Error('Unsafe CV download URL')
+
       // Extract filename from URL or use job title
       const filename = `${jobTitle.replace(/[^a-z0-9]/gi, '_')}_CV.pdf`
       const link = document.createElement('a')
-      link.href = cvLink
+      link.href = safeCvLink
       link.download = filename
       link.target = '_blank'
       document.body.appendChild(link)
@@ -147,7 +150,7 @@ export default function History() {
   // Calculate stats
   const stats = {
     totalMatches: jobs.length,
-    withCV: jobs.filter((j) => j.cv_link).length,
+    withCV: jobs.filter((j) => getSafeExternalUrl(j.cv_link)).length,
     applied: jobs.filter((j) => ['applied', 'interviewing', 'offer'].includes(j.application_status)).length,
     avgScore: jobs.length
       ? Math.round(jobs.reduce((acc, j) => acc + (j.score || 0), 0) / jobs.length)
@@ -321,7 +324,7 @@ export default function History() {
 
                     {/* CV Status */}
                     <div className="mt-2">
-                      {job.cv_link ? (
+                      {getSafeExternalUrl(job.cv_link) ? (
                         <span className="inline-flex items-center gap-1 text-xs text-emerald-400">
                           <CheckCircle2 className="w-3.5 h-3.5" />
                           CV Generated {formatGeneratedDate(job.cv_generated_at) && `on ${formatGeneratedDate(job.cv_generated_at)}`}
@@ -363,10 +366,10 @@ export default function History() {
                       <ClipboardCheck className="w-4 h-4" />
                       Workspace
                     </button>
-                    {job.cv_link ? (
+                    {getSafeExternalUrl(job.cv_link) ? (
                       <>
                         <a
-                          href={job.cv_link}
+                          href={getSafeExternalUrl(job.cv_link)}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="btn-icon text-text-muted hover:text-accent-400"

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -350,7 +350,7 @@ export const jobService = {
     return fetchAPI(`/api/v1/jobs/results?limit=${limit}&sort_by=${sortBy}`)
   },
 
-  // Get one matched job by result id
+  // Result IDs are opaque, path-safe PostgreSQL UUIDs or Airtable record IDs.
   async getResult(jobId) {
     return fetchAPI(`/api/v1/jobs/results/${encodeURIComponent(jobId)}`)
   },
@@ -363,7 +363,7 @@ export const jobService = {
 
   // Update application tracking status
   async updateApplicationStatus(jobId, applicationStatus, notes = null) {
-    return fetchAPI(`/api/v1/jobs/results/${jobId}/application`, {
+    return fetchAPI(`/api/v1/jobs/results/${encodeURIComponent(jobId)}/application`, {
       method: 'PATCH',
       body: JSON.stringify({
         application_status: applicationStatus,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,5 @@
 // API Configuration
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+const API_BASE_URL = import.meta.env?.VITE_API_URL || 'http://localhost:8000'
 
 // Lazy import telemetry to avoid circular dependencies
 let trackAPIError = null
@@ -348,6 +348,11 @@ export const jobService = {
   // Get job results with optional sorting
   async getResults(limit = 100, sortBy = 'date') {
     return fetchAPI(`/api/v1/jobs/results?limit=${limit}&sort_by=${sortBy}`)
+  },
+
+  // Get one matched job by result id
+  async getResult(jobId) {
+    return fetchAPI(`/api/v1/jobs/results/${encodeURIComponent(jobId)}`)
   },
 
   // Get matched jobs (alias for results)

--- a/frontend/src/services/api.test.js
+++ b/frontend/src/services/api.test.js
@@ -39,13 +39,13 @@ test('loads one matched job from the result endpoint', async () => {
   let request
   globalThis.fetch = async (url, options) => {
     request = { url, options }
-    return makeResponse({ id: 'job/123', job_title: 'Platform Engineer' })
+    return makeResponse({ id: 'recA1b2C3d4E5f6G7', job_title: 'Platform Engineer' })
   }
 
-  const result = await jobService.getResult('job/123')
+  const result = await jobService.getResult('recA1b2C3d4E5f6G7')
 
-  assert.equal(result.id, 'job/123')
-  assert.equal(request.url, 'http://localhost:8000/api/v1/jobs/results/job%2F123')
+  assert.equal(result.id, 'recA1b2C3d4E5f6G7')
+  assert.equal(request.url, 'http://localhost:8000/api/v1/jobs/results/recA1b2C3d4E5f6G7')
   assert.equal(request.options.credentials, 'include')
   assert.equal(request.options.headers.Authorization, 'Token test-token')
 })

--- a/frontend/src/services/api.test.js
+++ b/frontend/src/services/api.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { ErrorCodes, jobService } from './api.js'
+
+const originalFetch = globalThis.fetch
+const originalLocalStorage = globalThis.localStorage
+const originalFormData = globalThis.FormData
+
+function makeResponse(body, status = 200) {
+  const text = JSON.stringify(body)
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return body },
+    async text() { return text },
+  }
+}
+
+function installLocalStorage(token = null) {
+  globalThis.localStorage = {
+    getItem(key) {
+      return key === 'winningcv_auth_token' ? token : null
+    },
+  }
+}
+
+test.beforeEach(() => {
+  globalThis.FormData = class FormData {}
+})
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch
+  globalThis.localStorage = originalLocalStorage
+  globalThis.FormData = originalFormData
+})
+
+test('loads one matched job from the result endpoint', async () => {
+  installLocalStorage('test-token')
+  let request
+  globalThis.fetch = async (url, options) => {
+    request = { url, options }
+    return makeResponse({ id: 'job/123', job_title: 'Platform Engineer' })
+  }
+
+  const result = await jobService.getResult('job/123')
+
+  assert.equal(result.id, 'job/123')
+  assert.equal(request.url, 'http://localhost:8000/api/v1/jobs/results/job%2F123')
+  assert.equal(request.options.credentials, 'include')
+  assert.equal(request.options.headers.Authorization, 'Token test-token')
+})
+
+test('saves application tracking through the existing endpoint', async () => {
+  installLocalStorage()
+  let request
+  globalThis.fetch = async (url, options) => {
+    request = { url, options }
+    return makeResponse({
+      id: 'job-123',
+      application_status: 'applied',
+      application_notes: 'Submitted today',
+    })
+  }
+
+  const result = await jobService.updateApplicationStatus('job-123', 'applied', 'Submitted today')
+
+  assert.equal(result.application_status, 'applied')
+  assert.equal(request.url, 'http://localhost:8000/api/v1/jobs/results/job-123/application')
+  assert.equal(request.options.method, 'PATCH')
+  assert.deepEqual(JSON.parse(request.options.body), {
+    application_status: 'applied',
+    application_notes: 'Submitted today',
+  })
+})
+
+for (const [status, code] of [[404, ErrorCodes.NOT_FOUND], [501, ErrorCodes.SERVER_ERROR]]) {
+  test(`preserves ${status} responses for workspace handling`, async () => {
+    installLocalStorage()
+    globalThis.fetch = async () => makeResponse({ detail: 'Unavailable' }, status)
+
+    await assert.rejects(
+      () => status === 404
+        ? jobService.getResult('missing-job')
+        : jobService.updateApplicationStatus('job-123', 'saved'),
+      (error) => error.status === status && error.code === code,
+    )
+  })
+}

--- a/frontend/src/utils/applicationWorkspace.js
+++ b/frontend/src/utils/applicationWorkspace.js
@@ -1,0 +1,39 @@
+const TRACKING_STATUSES = new Set(['applied', 'interviewing', 'rejected', 'offer', 'archived'])
+
+export function getSafeExternalUrl(value) {
+  if (typeof value !== 'string' || !value.trim()) return null
+
+  try {
+    const url = new URL(value)
+    if (!['http:', 'https:'].includes(url.protocol)) return null
+    if (!url.hostname || url.username || url.password) return null
+    return url.href
+  } catch {
+    return null
+  }
+}
+
+export function getJobSource(value) {
+  const safeUrl = getSafeExternalUrl(value)
+  if (!safeUrl) return 'Source unavailable'
+
+  return new URL(safeUrl).hostname.replace(/^www\./, '')
+}
+
+export function getWorkflowProgress(job) {
+  const status = job?.application_status || 'saved'
+  const tailored = Boolean(job?.cv_link) || status === 'cv_generated' || TRACKING_STATUSES.has(status)
+  const applied = TRACKING_STATUSES.has(status)
+
+  return {
+    analyse: true,
+    tailor: tailored,
+    apply: applied,
+    track: applied,
+  }
+}
+
+export function formatFitScore(score, scale = 10) {
+  if (score == null || Number.isNaN(Number(score))) return 'Unavailable'
+  return `${Math.round((Number(score) / scale) * 100)}%`
+}

--- a/frontend/src/utils/applicationWorkspace.test.js
+++ b/frontend/src/utils/applicationWorkspace.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  formatFitScore,
+  getJobSource,
+  getSafeExternalUrl,
+  getWorkflowProgress,
+} from './applicationWorkspace.js'
+
+test('accepts only credential-free HTTP and HTTPS apply URLs', () => {
+  assert.equal(getSafeExternalUrl('https://jobs.example.com/apply?id=42'), 'https://jobs.example.com/apply?id=42')
+  assert.equal(getSafeExternalUrl('http://jobs.example.com/role'), 'http://jobs.example.com/role')
+  assert.equal(getSafeExternalUrl('javascript:alert(1)'), null)
+  assert.equal(getSafeExternalUrl('https://user:secret@jobs.example.com/apply'), null)
+  assert.equal(getSafeExternalUrl('/relative/apply'), null)
+  assert.equal(getSafeExternalUrl('not a URL'), null)
+})
+
+test('uses a validated hostname as the source label', () => {
+  assert.equal(getJobSource('https://www.seek.com.au/job/123'), 'seek.com.au')
+  assert.equal(getJobSource('javascript:alert(1)'), 'Source unavailable')
+})
+
+test('derives workflow progress from persisted job data', () => {
+  assert.deepEqual(getWorkflowProgress({ application_status: 'saved' }), {
+    analyse: true,
+    tailor: false,
+    apply: false,
+    track: false,
+  })
+  assert.deepEqual(getWorkflowProgress({ application_status: 'saved', cv_link: '/cv.pdf' }), {
+    analyse: true,
+    tailor: true,
+    apply: false,
+    track: false,
+  })
+  assert.deepEqual(getWorkflowProgress({ application_status: 'interviewing' }), {
+    analyse: true,
+    tailor: true,
+    apply: true,
+    track: true,
+  })
+})
+
+test('formats scores using their existing scale', () => {
+  assert.equal(formatFitScore(8.4), '84%')
+  assert.equal(formatFitScore(76, 100), '76%')
+  assert.equal(formatFitScore(null), 'Unavailable')
+})

--- a/frontend/src/utils/applicationWorkspace.test.js
+++ b/frontend/src/utils/applicationWorkspace.test.js
@@ -11,6 +11,7 @@ test('accepts only credential-free HTTP and HTTPS apply URLs', () => {
   assert.equal(getSafeExternalUrl('https://jobs.example.com/apply?id=42'), 'https://jobs.example.com/apply?id=42')
   assert.equal(getSafeExternalUrl('http://jobs.example.com/role'), 'http://jobs.example.com/role')
   assert.equal(getSafeExternalUrl('javascript:alert(1)'), null)
+  assert.equal(getSafeExternalUrl('data:application/pdf;base64,JVBERi0x'), null)
   assert.equal(getSafeExternalUrl('https://user:secret@jobs.example.com/apply'), null)
   assert.equal(getSafeExternalUrl('/relative/apply'), null)
   assert.equal(getSafeExternalUrl('not a URL'), null)

--- a/init-db/02-data-storage-schema.sql
+++ b/init-db/02-data-storage-schema.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     job_title VARCHAR(500),
     job_description TEXT,
     job_date TIMESTAMP WITH TIME ZONE,
-    job_link VARCHAR(2000) UNIQUE,
+    job_link VARCHAR(2000),
     company VARCHAR(255),
     location VARCHAR(255),
     matching_score INTEGER DEFAULT 0,
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_user_email_job_link ON jobs(user_email, job_link);
 CREATE INDEX IF NOT EXISTS idx_jobs_job_link ON jobs(job_link);
 CREATE INDEX IF NOT EXISTS idx_jobs_user_email ON jobs(user_email);
 CREATE INDEX IF NOT EXISTS idx_jobs_created_at ON jobs(created_at DESC);

--- a/init-db/06-jobs-user-link-uniqueness.sql
+++ b/init-db/06-jobs-user-link-uniqueness.sql
@@ -1,0 +1,29 @@
+-- Allow different users to save the same listing while preserving per-user deduplication.
+-- Idempotent for both bootstrap and existing databases.
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    SELECT con.conname
+      INTO constraint_name
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid = con.conrelid
+      JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+     WHERE nsp.nspname = current_schema()
+       AND rel.relname = 'jobs'
+       AND con.contype = 'u'
+       AND (
+           SELECT array_agg(att.attname ORDER BY key_column.ordinality)
+             FROM unnest(con.conkey) WITH ORDINALITY AS key_column(attnum, ordinality)
+             JOIN pg_attribute att
+               ON att.attrelid = rel.oid
+              AND att.attnum = key_column.attnum
+       ) = ARRAY['job_link']::name[];
+
+    IF constraint_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE jobs DROP CONSTRAINT %I', constraint_name);
+    END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_user_email_job_link
+    ON jobs(user_email, job_link);

--- a/job_processing/core.py
+++ b/job_processing/core.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Callable, Dict, List, Optional
 
 from cv.cv_generator import CVGenerator
-from data_store.storage_factory import get_data_manager
+from data_store.storage_factory import ShadowWriteError, get_data_manager
 from job_sources.additional_job_search import AdditionalJobProcessor
 from job_sources.linkedin_job_scraper import LinkedInJobScraper
 from job_sources.seek_job_scraper import SeekJobScraper
@@ -71,6 +71,9 @@ class JobProcessor:
                     count = future.result()
                     logger.info(f"✔️ {name} added {count} new jobs")
                     results[name] = count
+                except ShadowWriteError:
+                    logger.exception("❌ %s failed because a shadow write diverged", name)
+                    raise
                 except Exception as e:
                     logger.error(f"❌ {name} failed: {e}")
                     results[name] = 0
@@ -131,6 +134,9 @@ class JobProcessor:
                         logger.info(f"Added LinkedIn job: {normalized['Job Title']} [{job_url}]")
             logger.info(f"Added {new_jobs} new LinkedIn jobs")
             return new_jobs
+        except ShadowWriteError:
+            logger.exception("LinkedIn job processing stopped because a shadow write diverged")
+            raise
         except Exception as e:
             logger.error(f"LinkedIn job processing failed: {str(e)}")
             return 0
@@ -173,6 +179,9 @@ class JobProcessor:
                     logger.info(f"Added Seek job: {normalized['Job Title']} [{job_url}]")
             logger.info(f"Added {new_jobs} new Seek jobs")
             return new_jobs
+        except ShadowWriteError:
+            logger.exception("Seek job processing stopped because a shadow write diverged")
+            raise
         except Exception as e:
             logger.error(f"Seek job processing failed: {str(e)}")
             return 0
@@ -207,6 +216,9 @@ class JobProcessor:
                     logger.info(f"Added job from additional source: {job['Job Title']}")
             logger.info(f"Added {new_jobs_added} jobs from additional sources")
             return new_jobs_added
+        except ShadowWriteError:
+            logger.exception("Additional job processing stopped because a shadow write diverged")
+            raise
         except Exception as e:
             logger.error(f"Additional job processing failed: {str(e)}")
             return 0

--- a/job_processing/core.py
+++ b/job_processing/core.py
@@ -95,8 +95,12 @@ class JobProcessor:
         logger.info("Processing LinkedIn jobs...")
         try:
             target_urls = self.get_target_urls()
-            existing_links = set(canonicalize_url(link) for link in self.airtable.get_existing_job_links())
-            # existing_links = self.airtable.get_existing_job_links()
+            existing_links = {
+                canonicalize_url(link)
+                for link in self.airtable.get_existing_job_links(
+                    user_email=self.config.user_email
+                )
+            }
             new_jobs = 0
             for url in target_urls:
                 logger.info(f"Scraping LinkedIn jobs from URL: {url}")
@@ -114,7 +118,7 @@ class JobProcessor:
                         logger.info(f"Job {job_url} already exists (in-memory dedup), skipping.")
                         continue
                     # Airtable-level check (race condition safety)
-                    if self.airtable.job_exists(job_url):
+                    if self.airtable.job_exists(job_url, user_email=self.config.user_email):
                         logger.info(f"Job {job_url} already exists in Airtable, skipping.")
                         existing_links.add(job_url)
                         continue
@@ -140,8 +144,12 @@ class JobProcessor:
             if not job_list:
                 logger.warning("No jobs returned from Seek scraper.")
                 return 0
-            # existing_links = self.airtable.get_existing_job_links()
-            existing_links = set(canonicalize_url(link) for link in self.airtable.get_existing_job_links())
+            existing_links = {
+                canonicalize_url(link)
+                for link in self.airtable.get_existing_job_links(
+                    user_email=self.config.user_email
+                )
+            }
             new_jobs = 0
             for job_data in job_list:
                 job_url = canonicalize_url(job_data.get("job_url"))
@@ -153,7 +161,7 @@ class JobProcessor:
                     logger.info(f"Job {job_url} already exists, skipping.")
                     continue
                 # Airtable-level check (race condition safety)
-                if self.airtable.job_exists(job_url):
+                if self.airtable.job_exists(job_url, user_email=self.config.user_email):
                     logger.info(f"Job {job_url} already exists in Airtable, skipping.")
                     existing_links.add(job_url)
                     continue
@@ -176,8 +184,12 @@ class JobProcessor:
             processed_jobs = self.additional_processor.scrape_and_process_jobs()
             if not processed_jobs:
                 return 0
-            # existing_links = self.airtable.get_existing_job_links()
-            existing_links = set(canonicalize_url(link) for link in self.airtable.get_existing_job_links())
+            existing_links = {
+                canonicalize_url(link)
+                for link in self.airtable.get_existing_job_links(
+                    user_email=self.config.user_email
+                )
+            }
             new_jobs_added = 0
 
             for job in processed_jobs:
@@ -185,7 +197,7 @@ class JobProcessor:
                 if not job_url or job_url in existing_links:
                     continue
                 # Airtable-level check (race condition safety)
-                if self.airtable.job_exists(job_url):
+                if self.airtable.job_exists(job_url, user_email=self.config.user_email):
                     logger.info(f"Job {job_url} already exists in Airtable, skipping.")
                     existing_links.add(job_url)
                     continue
@@ -218,7 +230,7 @@ class JobProcessor:
                 return jobs_with_cv
 
             # Fetch unprocessed jobs (no CV Link & has job desc)
-            unprocessed_jobs = self.airtable.get_unprocessed_jobs()
+            unprocessed_jobs = self.airtable.get_unprocessed_jobs(user_email=self.config.user_email)
             total_jobs = len(unprocessed_jobs)
             logger.info(f"Found {total_jobs} unprocessed jobs in Airtable.")
             self._update_progress(51, f"Analyzing {total_jobs} jobs against your CV...")
@@ -263,6 +275,7 @@ class JobProcessor:
                     recommendation=analysis.get('recommendation') if analysis else None,
                     matched_keywords=ats_breakdown.get('matched_keywords') if ats_breakdown else None,
                     missing_keywords=ats_breakdown.get('missing_keywords') if ats_breakdown else None,
+                    user_email=self.config.user_email,
                 )
                 if not updated_record:
                     logger.warning(f"Failed to update job with match score for {job_link}.")
@@ -285,6 +298,7 @@ class JobProcessor:
                             recommendation=analysis.get('recommendation') if analysis else None,
                             matched_keywords=ats_breakdown.get('matched_keywords') if ats_breakdown else None,
                             missing_keywords=ats_breakdown.get('missing_keywords') if ats_breakdown else None,
+                            user_email=self.config.user_email,
                         )
                         if updated_record:
                             logger.info(f"Generated targeted CV for '{job_title}' -> {cv_url}")

--- a/scripts/prod_migrate_db.sh
+++ b/scripts/prod_migrate_db.sh
@@ -16,3 +16,6 @@ ALTER TABLE cv_versions ADD COLUMN IF NOT EXISTS docx_storage_path VARCHAR(500);
 ALTER TABLE cv_versions ADD COLUMN IF NOT EXISTS docx_file_size INTEGER DEFAULT 0;
 ALTER TABLE cv_versions ADD COLUMN IF NOT EXISTS docx_content_hash VARCHAR(64);
 SQL
+
+# Apply file-backed migrations that alter constraints/indexes.
+docker exec -i "$POSTGRES_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 < init-db/06-jobs-user-link-uniqueness.sql

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -1,0 +1,92 @@
+"""Regression tests for observable job-search shadow-write failures."""
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from api.routes import jobs
+from data_store.storage_factory import ShadowWriteError
+from job_processing.core import JobProcessor
+
+
+def _processor():
+    processor = JobProcessor.__new__(JobProcessor)
+    processor.config = SimpleNamespace(user_email="owner@example.com")
+    processor.airtable = Mock()
+    processor.airtable.get_existing_job_links.return_value = set()
+    processor.airtable.job_exists.return_value = False
+    processor.airtable.create_job_record.side_effect = ShadowWriteError("shadow diverged")
+    processor.content_cleaner = Mock()
+    processor.content_cleaner.clean_html.side_effect = lambda value: value
+    processor.linkedin_scraper = Mock()
+    processor.linkedin_scraper.scrape_job_page.return_value = [
+        {"title": "Engineer", "job_url": "https://jobs.example.com/linkedin", "description": "Build"}
+    ]
+    processor.seek_scraper = Mock()
+    processor.seek_scraper.scrape_jobs.return_value = [
+        {"title": "Engineer", "job_url": "https://jobs.example.com/seek", "description": "Build"}
+    ]
+    processor.additional_processor = Mock()
+    processor.additional_processor.scrape_and_process_jobs.return_value = [
+        {"Job Title": "Engineer", "Job Link": "https://jobs.example.com/additional", "Job Description": "Build"}
+    ]
+    processor.get_target_urls = Mock(return_value=["https://linkedin.example/search"])
+    processor._progress_callback = None
+    return processor
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["_process_linkedin_jobs", "_process_seek_jobs", "_process_additional_sources"],
+)
+def test_scraper_boundaries_reraise_shadow_write_error(method_name):
+    processor = _processor()
+
+    with pytest.raises(ShadowWriteError, match="shadow diverged"):
+        getattr(processor, method_name)()
+
+
+def test_scraper_boundary_still_handles_ordinary_errors():
+    processor = _processor()
+    processor.seek_scraper.scrape_jobs.side_effect = RuntimeError("board unavailable")
+
+    assert processor._process_seek_jobs() == 0
+
+
+def test_process_jobs_does_not_report_no_jobs_after_shadow_write_failure():
+    processor = _processor()
+    progress = []
+    processor._progress_callback = lambda percent, message: progress.append((percent, message))
+    processor._process_linkedin_jobs = Mock(side_effect=ShadowWriteError("shadow diverged"))
+    processor._process_seek_jobs = Mock(return_value=0)
+    processor._process_additional_sources = Mock(return_value=0)
+
+    with pytest.raises(ShadowWriteError, match="shadow diverged"):
+        processor.process_jobs()
+
+    assert all(message != "No new jobs found" for _, message in progress)
+
+
+def test_background_search_marks_shadow_write_failure_failed(monkeypatch):
+    task_manager = Mock()
+    processor = Mock()
+    processor.process_jobs.side_effect = ShadowWriteError("shadow diverged")
+    processor_factory = Mock(return_value=processor)
+    monkeypatch.setattr(jobs, "_get_task_manager", lambda: task_manager)
+    monkeypatch.setattr(jobs, "get_data_manager", Mock(return_value=Mock()))
+    monkeypatch.setattr(jobs, "JobProcessor", processor_factory)
+
+    jobs._run_job_search("task-123", "owner@example.com", {})
+
+    failed_calls = [
+        call for call in task_manager.update_task.call_args_list
+        if call.kwargs.get("status") == jobs.SearchStatus.FAILED.value
+    ]
+    completed_calls = [
+        call for call in task_manager.update_task.call_args_list
+        if call.kwargs.get("status") == jobs.SearchStatus.COMPLETED.value
+    ]
+    assert len(failed_calls) == 1
+    assert failed_calls[0].kwargs["message"] == "shadow diverged"
+    assert failed_calls[0].kwargs["error_details"] == "shadow diverged"
+    assert completed_calls == []

--- a/tests/test_job_result_workspace.py
+++ b/tests/test_job_result_workspace.py
@@ -1,0 +1,111 @@
+"""Focused tests for the application workspace job-result routes."""
+from unittest.mock import Mock
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import jobs
+from api.schemas.auth import UserInfo
+from api.schemas.jobs import ApplicationStatusUpdate
+
+
+def make_user(email: str = "owner@example.com") -> UserInfo:
+    return UserInfo(
+        auth_user_id=1,
+        email=email,
+        display_name="Owner",
+        provider="test",
+        is_verified=True,
+    )
+
+
+def make_record(**field_overrides):
+    fields = {
+        "User Email": "owner@example.com",
+        "Job Title": "Platform Engineer",
+        "Company": "Example Co",
+        "Location": "Melbourne",
+        "Matching Score": 8.7,
+        "Job Link": "https://jobs.example.com/123",
+        "Job Description": "Build reliable systems",
+        "Application Status": "saved",
+    }
+    fields.update(field_overrides)
+    return {"id": "job-123", "fields": fields}
+
+
+@pytest.mark.asyncio
+async def test_get_job_result_returns_owned_job(monkeypatch):
+    manager = Mock()
+    manager.get_records_by_filter.return_value = [make_record()]
+    history_manager = Mock()
+    history_manager.get_history_by_user.return_value = []
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
+    monkeypatch.setattr(jobs, "get_history_manager", lambda: history_manager)
+
+    result = await jobs.get_job_result("job-123", make_user())
+
+    assert result.id == "job-123"
+    assert result.job_title == "Platform Engineer"
+    assert result.application_status.value == "saved"
+    manager.get_records_by_filter.assert_called_once_with("{User Email} = 'owner@example.com'")
+
+
+@pytest.mark.asyncio
+async def test_get_job_result_hides_missing_or_foreign_job(monkeypatch):
+    manager = Mock()
+    manager.get_records_by_filter.return_value = []
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await jobs.get_job_result("foreign-job", make_user())
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Job not found"
+
+
+@pytest.mark.asyncio
+async def test_update_application_status_returns_saved_job(monkeypatch):
+    record = make_record()
+    manager = Mock()
+
+    def update_application_status(**kwargs):
+        record["fields"]["Application Status"] = kwargs["application_status"]
+        record["fields"]["Application Notes"] = kwargs["application_notes"]
+        return {"id": kwargs["job_id"]}
+
+    manager.update_application_status.side_effect = update_application_status
+    manager.get_records_by_filter.return_value = [record]
+    history_manager = Mock()
+    history_manager.get_history_by_user.return_value = []
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
+    monkeypatch.setattr(jobs, "get_history_manager", lambda: history_manager)
+
+    result = await jobs.update_application_status_result(
+        "job-123",
+        ApplicationStatusUpdate(application_status="applied", application_notes="Submitted today"),
+        make_user(),
+    )
+
+    assert result.application_status.value == "applied"
+    assert result.application_notes == "Submitted today"
+    manager.update_application_status.assert_called_once_with(
+        job_id="job-123",
+        user_email="owner@example.com",
+        application_status="applied",
+        application_notes="Submitted today",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_application_status_reports_unsupported_backend(monkeypatch):
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: object())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await jobs.update_application_status_result(
+            "job-123",
+            ApplicationStatusUpdate(application_status="saved"),
+            make_user(),
+        )
+
+    assert exc_info.value.status_code == 501

--- a/tests/test_job_result_workspace.py
+++ b/tests/test_job_result_workspace.py
@@ -1,4 +1,5 @@
 """Focused tests for the application workspace job-result routes."""
+from contextlib import contextmanager
 from unittest.mock import Mock
 
 import pytest
@@ -7,6 +8,8 @@ from fastapi import HTTPException
 from api.routes import jobs
 from api.schemas.auth import UserInfo
 from api.schemas.jobs import ApplicationStatusUpdate
+from data_store.airtable_manager import AirtableManager
+from data_store.postgres_manager import PostgresManager
 
 
 def make_user(email: str = "owner@example.com") -> UserInfo:
@@ -37,7 +40,7 @@ def make_record(**field_overrides):
 @pytest.mark.asyncio
 async def test_get_job_result_returns_owned_job(monkeypatch):
     manager = Mock()
-    manager.get_records_by_filter.return_value = [make_record()]
+    manager.get_job_result.return_value = make_record()
     history_manager = Mock()
     history_manager.get_history_by_user.return_value = []
     monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
@@ -48,13 +51,16 @@ async def test_get_job_result_returns_owned_job(monkeypatch):
     assert result.id == "job-123"
     assert result.job_title == "Platform Engineer"
     assert result.application_status.value == "saved"
-    manager.get_records_by_filter.assert_called_once_with("{User Email} = 'owner@example.com'")
+    manager.get_job_result.assert_called_once_with(
+        job_id="job-123",
+        user_email="owner@example.com",
+    )
 
 
 @pytest.mark.asyncio
 async def test_get_job_result_hides_missing_or_foreign_job(monkeypatch):
     manager = Mock()
-    manager.get_records_by_filter.return_value = []
+    manager.get_job_result.return_value = None
     monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
 
     with pytest.raises(HTTPException) as exc_info:
@@ -75,7 +81,7 @@ async def test_update_application_status_returns_saved_job(monkeypatch):
         return {"id": kwargs["job_id"]}
 
     manager.update_application_status.side_effect = update_application_status
-    manager.get_records_by_filter.return_value = [record]
+    manager.get_job_result.return_value = record
     history_manager = Mock()
     history_manager.get_history_by_user.return_value = []
     monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
@@ -109,3 +115,57 @@ async def test_update_application_status_reports_unsupported_backend(monkeypatch
         )
 
     assert exc_info.value.status_code == 501
+
+
+def test_postgres_job_lookup_parameterizes_apostrophe_email():
+    row = {
+        "id": "d5b0fbe6-1e2b-4e65-90b0-2bb092f66d14",
+        "user_email": "o'connor@example.com",
+        "job_title": "Platform Engineer",
+        "job_description": "Build reliable systems",
+        "job_date": None,
+        "job_link": "https://jobs.example.com/123",
+        "company": "Example Co",
+        "location": "Melbourne",
+        "matching_score": 8.7,
+        "cv_link": None,
+        "match_reasons": None,
+        "match_suggestions": None,
+        "ats_score": None,
+        "hr_score": None,
+        "llm_score": None,
+        "hr_recommendation": None,
+        "matched_keywords": None,
+        "missing_keywords": None,
+        "application_status": "saved",
+        "application_notes": None,
+        "applied_at": None,
+        "created_at": None,
+        "updated_at": None,
+    }
+    cursor = Mock()
+    cursor.fetchone.return_value = row
+    manager = PostgresManager("postgresql://unused")
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    manager.get_cursor = fake_cursor
+    result = manager.get_job_result(row["id"], row["user_email"])
+
+    assert result["id"] == row["id"]
+    query, params = cursor.execute.call_args.args
+    assert "WHERE id = %s AND user_email = %s" in query
+    assert params == (row["id"], "o'connor@example.com")
+
+
+def test_airtable_job_lookup_checks_exact_owner_without_formula():
+    manager = AirtableManager.__new__(AirtableManager)
+    manager.table = Mock()
+    manager.logger = Mock()
+    manager.table.get.return_value = make_record(**{"User Email": "o'connor@example.com"})
+
+    assert manager.get_job_result("job-123", "o'connor@example.com")["id"] == "job-123"
+    assert manager.get_job_result("job-123", "foreign@example.com") is None
+    manager.table.get.assert_called_with("job-123")

--- a/tests/test_job_result_workspace.py
+++ b/tests/test_job_result_workspace.py
@@ -13,7 +13,7 @@ from api.schemas.auth import UserInfo
 from api.schemas.jobs import ApplicationStatusUpdate
 from data_store.airtable_manager import AirtableManager
 from data_store.postgres_manager import PostgresManager
-from data_store.storage_factory import DualWriteDataManager
+from data_store.storage_factory import DualWriteDataManager, ShadowWriteError
 
 
 def make_user(email: str = "owner@example.com") -> UserInfo:
@@ -33,6 +33,7 @@ def make_record(**field_overrides):
         "Company": "Example Co",
         "Location": "Melbourne",
         "Matching Score": 8.7,
+        "ATS Score": 92,
         "Job Link": "https://jobs.example.com/123",
         "Job Description": "Build reliable systems",
         "Application Status": "saved",
@@ -55,6 +56,8 @@ async def test_get_job_result_returns_owned_job(monkeypatch):
     assert result.id == "job-123"
     assert result.job_title == "Platform Engineer"
     assert result.application_status.value == "saved"
+    assert result.score == 8.7
+    assert result.score_breakdown.ats_score == 92
     manager.get_job_result.assert_called_once_with(
         job_id="job-123",
         user_email="owner@example.com",
@@ -163,6 +166,21 @@ def test_postgres_job_lookup_parameterizes_apostrophe_email():
     assert "WHERE id::text = %s AND user_email = %s" in query
     assert params == (row["id"], "o'connor@example.com")
 
+
+def test_postgres_list_jobs_parameterizes_apostrophe_email():
+    cursor = Mock()
+    cursor.fetchall.return_value = []
+    manager = PostgresManager("postgresql://unused")
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    manager.get_cursor = fake_cursor
+    assert manager.get_jobs_by_user("o'connor@example.com") == []
+    query, params = cursor.execute.call_args.args
+    assert "WHERE user_email = %s" in query
+    assert params == ("o'connor@example.com",)
 
 def test_airtable_job_lookup_checks_exact_owner_without_formula():
     manager = AirtableManager.__new__(AirtableManager)
@@ -341,18 +359,23 @@ def test_dual_write_application_update_uses_airtable_primary_and_postgres_shadow
     )
 
 
-def test_dual_write_application_update_tolerates_shadow_failure():
+@pytest.mark.parametrize("shadow_result", [None, RuntimeError("postgres unavailable")])
+def test_dual_write_application_update_reports_shadow_failure(shadow_result, caplog):
     airtable = Mock()
     postgres = Mock()
-    airtable.update_application_status.return_value = {"id": "job-123"}
-    postgres.update_application_status.side_effect = RuntimeError("postgres unavailable")
+    airtable.update_application_status.return_value = make_record()
+    if isinstance(shadow_result, Exception):
+        postgres.update_application_status.side_effect = shadow_result
+    else:
+        postgres.update_application_status.return_value = shadow_result
     manager = DualWriteDataManager(airtable, postgres)
 
-    result = manager.update_application_status(
-        "job-123", "owner@example.com", "saved", None
-    )
+    with pytest.raises(ShadowWriteError):
+        manager.update_application_status(
+            "job-123", "owner@example.com", "saved", None
+        )
 
-    assert result == {"id": "job-123"}
+    assert "Postgres shadow write" in caplog.text
 
 
 def test_postgres_dual_write_update_uses_owner_scoped_job_link():
@@ -399,3 +422,58 @@ async def test_routes_report_storage_failure_as_service_unavailable(monkeypatch,
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "Job storage unavailable"
+
+
+@pytest.mark.asyncio
+async def test_list_results_uses_typed_user_lookup(monkeypatch):
+    manager = Mock()
+    manager.get_jobs_by_user.return_value = [make_record()]
+    history_manager = Mock()
+    history_manager.get_history_by_user.return_value = []
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
+    monkeypatch.setattr(jobs, "get_history_manager", lambda: history_manager)
+
+    result = await jobs.get_job_results(make_user("o'connor@example.com"))
+
+    assert result.total == 1
+    manager.get_jobs_by_user.assert_called_once_with("o'connor@example.com")
+    manager.get_records_by_filter.assert_not_called()
+
+
+@pytest.mark.parametrize("shadow_result", [None, RuntimeError("postgres unavailable")])
+def test_dual_write_create_reports_shadow_failure(shadow_result, caplog):
+    airtable = Mock()
+    postgres = Mock()
+    airtable.create_job_record.return_value = make_record()
+    if isinstance(shadow_result, Exception):
+        postgres.create_job_record.side_effect = shadow_result
+    else:
+        postgres.create_job_record.return_value = shadow_result
+    manager = DualWriteDataManager(airtable, postgres)
+
+    with pytest.raises(ShadowWriteError):
+        manager.create_job_record({"Job Link": "https://jobs.example.com/123"}, "owner@example.com")
+
+    assert "Postgres shadow write" in caplog.text
+
+
+@pytest.mark.parametrize("shadow_result", [None, RuntimeError("postgres unavailable")])
+def test_dual_write_cv_update_reports_shadow_failure(shadow_result, caplog):
+    airtable = Mock()
+    postgres = Mock()
+    airtable.update_cv_info.return_value = make_record()
+    if isinstance(shadow_result, Exception):
+        postgres.update_cv_info.side_effect = shadow_result
+    else:
+        postgres.update_cv_info.return_value = shadow_result
+    manager = DualWriteDataManager(airtable, postgres)
+
+    with pytest.raises(ShadowWriteError):
+        manager.update_cv_info(
+            "https://jobs.example.com/123",
+            9,
+            "https://files.example.com/cv.pdf",
+            user_email="owner@example.com",
+        )
+
+    assert "Postgres shadow write" in caplog.text

--- a/tests/test_job_result_workspace.py
+++ b/tests/test_job_result_workspace.py
@@ -1,6 +1,9 @@
 """Focused tests for the application workspace job-result routes."""
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from unittest.mock import Mock
+
+from requests import HTTPError, Response
 
 import pytest
 from fastapi import HTTPException
@@ -10,6 +13,7 @@ from api.schemas.auth import UserInfo
 from api.schemas.jobs import ApplicationStatusUpdate
 from data_store.airtable_manager import AirtableManager
 from data_store.postgres_manager import PostgresManager
+from data_store.storage_factory import DualWriteDataManager
 
 
 def make_user(email: str = "owner@example.com") -> UserInfo:
@@ -156,7 +160,7 @@ def test_postgres_job_lookup_parameterizes_apostrophe_email():
 
     assert result["id"] == row["id"]
     query, params = cursor.execute.call_args.args
-    assert "WHERE id = %s AND user_email = %s" in query
+    assert "WHERE id::text = %s AND user_email = %s" in query
     assert params == (row["id"], "o'connor@example.com")
 
 
@@ -169,3 +173,229 @@ def test_airtable_job_lookup_checks_exact_owner_without_formula():
     assert manager.get_job_result("job-123", "o'connor@example.com")["id"] == "job-123"
     assert manager.get_job_result("job-123", "foreign@example.com") is None
     manager.table.get.assert_called_with("job-123")
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [
+        datetime(2026, 7, 25, 1, 30, tzinfo=timezone.utc),
+        datetime(2026, 7, 25, 1, 30),
+    ],
+)
+def test_job_result_accepts_postgres_datetime_for_cv_history(created_at):
+    record = make_record(**{"CV Link": "https://example.com/cv.pdf"})
+
+    result = jobs._job_result_from_record(
+        record,
+        {"https://example.com/cv.pdf": created_at},
+    )
+
+    assert result.cv_generated_at == created_at
+
+
+def test_postgres_application_update_is_owner_scoped_and_persists():
+    cursor = Mock()
+    cursor.fetchone.return_value = {"id": "d5b0fbe6-1e2b-4e65-90b0-2bb092f66d14"}
+    manager = PostgresManager("postgresql://unused")
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    manager.get_cursor = fake_cursor
+    result = manager.update_application_status(
+        "d5b0fbe6-1e2b-4e65-90b0-2bb092f66d14",
+        "owner@example.com",
+        "applied",
+        "Submitted today",
+    )
+
+    assert result == {"id": "d5b0fbe6-1e2b-4e65-90b0-2bb092f66d14"}
+    query, params = cursor.execute.call_args.args
+    assert "WHERE id::text = %s AND user_email = %s" in query
+    assert params == (
+        "applied",
+        "Submitted today",
+        "applied",
+        "d5b0fbe6-1e2b-4e65-90b0-2bb092f66d14",
+        "owner@example.com",
+    )
+
+
+def test_postgres_application_update_denies_cross_user():
+    cursor = Mock()
+    cursor.fetchone.return_value = None
+    manager = PostgresManager("postgresql://unused")
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    manager.get_cursor = fake_cursor
+    result = manager.update_application_status(
+        "d5b0fbe6-1e2b-4e65-90b0-2bb092f66d14",
+        "foreign@example.com",
+        "applied",
+        None,
+    )
+
+    assert result is None
+    _, params = cursor.execute.call_args.args
+    assert params[-2:] == (
+        "d5b0fbe6-1e2b-4e65-90b0-2bb092f66d14",
+        "foreign@example.com",
+    )
+
+
+def test_postgres_lookup_propagates_backend_failure():
+    manager = PostgresManager("postgresql://unused")
+
+    @contextmanager
+    def failing_cursor():
+        raise RuntimeError("database unavailable")
+        yield
+
+    manager.get_cursor = failing_cursor
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        manager.get_job_result("job-123", "owner@example.com")
+
+
+def test_airtable_application_update_persists_for_exact_owner():
+    manager = AirtableManager.__new__(AirtableManager)
+    manager.table = Mock()
+    manager.logger = Mock()
+    manager.table.get.return_value = make_record()
+    manager.table.update.return_value = make_record(
+        **{
+            "Application Status": "applied",
+            "Application Notes": "Submitted today",
+        }
+    )
+
+    result = manager.update_application_status(
+        "job-123", "owner@example.com", "applied", "Submitted today"
+    )
+
+    assert result["fields"]["Application Status"] == "applied"
+    updated_id, fields = manager.table.update.call_args.args
+    assert updated_id == "job-123"
+    assert fields["Application Status"] == "applied"
+    assert fields["Application Notes"] == "Submitted today"
+    assert datetime.fromisoformat(fields["Applied At"]).tzinfo is not None
+
+
+def test_airtable_application_update_denies_cross_user():
+    manager = AirtableManager.__new__(AirtableManager)
+    manager.table = Mock()
+    manager.logger = Mock()
+    manager.table.get.return_value = make_record()
+
+    assert manager.update_application_status(
+        "job-123", "foreign@example.com", "applied", "Should not save"
+    ) is None
+    manager.table.update.assert_not_called()
+
+
+def test_airtable_lookup_returns_none_for_real_not_found_response():
+    manager = AirtableManager.__new__(AirtableManager)
+    manager.table = Mock()
+    manager.logger = Mock()
+    response = Response()
+    response.status_code = 404
+    manager.table.get.side_effect = HTTPError(response=response)
+
+    assert manager.get_job_result("missing-job", "owner@example.com") is None
+
+
+def test_airtable_lookup_propagates_backend_failure():
+    manager = AirtableManager.__new__(AirtableManager)
+    manager.table = Mock()
+    manager.logger = Mock()
+    manager.table.get.side_effect = RuntimeError("airtable unavailable")
+
+    with pytest.raises(RuntimeError, match="airtable unavailable"):
+        manager.get_job_result("job-123", "owner@example.com")
+
+
+def test_dual_write_application_update_uses_airtable_primary_and_postgres_shadow():
+    airtable = Mock()
+    postgres = Mock()
+    airtable.update_application_status.return_value = make_record()
+    manager = DualWriteDataManager(airtable, postgres)
+
+    result = manager.update_application_status(
+        "job-123", "owner@example.com", "interviewing", "Phone screen"
+    )
+
+    assert result["id"] == "job-123"
+    airtable.update_application_status.assert_called_once_with(
+        "job-123", "owner@example.com", "interviewing", "Phone screen"
+    )
+    postgres.update_application_status.assert_called_once_with(
+        "job-123",
+        "owner@example.com",
+        "interviewing",
+        "Phone screen",
+        job_link="https://jobs.example.com/123",
+    )
+
+
+def test_dual_write_application_update_tolerates_shadow_failure():
+    airtable = Mock()
+    postgres = Mock()
+    airtable.update_application_status.return_value = {"id": "job-123"}
+    postgres.update_application_status.side_effect = RuntimeError("postgres unavailable")
+    manager = DualWriteDataManager(airtable, postgres)
+
+    result = manager.update_application_status(
+        "job-123", "owner@example.com", "saved", None
+    )
+
+    assert result == {"id": "job-123"}
+
+
+def test_postgres_dual_write_update_uses_owner_scoped_job_link():
+    cursor = Mock()
+    cursor.fetchone.return_value = {"id": 42}
+    manager = PostgresManager("postgresql://unused")
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    manager.get_cursor = fake_cursor
+    result = manager.update_application_status(
+        "recAirtable",
+        "owner@example.com",
+        "applied",
+        "Submitted",
+        job_link="https://jobs.example.com/123",
+    )
+
+    assert result == {"id": "42"}
+    query, params = cursor.execute.call_args.args
+    assert "WHERE job_link = %s AND user_email = %s" in query
+    assert params[-2:] == ("https://jobs.example.com/123", "owner@example.com")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["lookup", "update"])
+async def test_routes_report_storage_failure_as_service_unavailable(monkeypatch, operation):
+    manager = Mock()
+    manager.get_job_result.side_effect = RuntimeError("backend unavailable")
+    manager.update_application_status.side_effect = RuntimeError("backend unavailable")
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
+
+    with pytest.raises(HTTPException) as exc_info:
+        if operation == "lookup":
+            await jobs.get_job_result("job-123", make_user())
+        else:
+            await jobs.update_application_status_result(
+                "job-123",
+                ApplicationStatusUpdate(application_status="saved"),
+                make_user(),
+            )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Job storage unavailable"

--- a/tests/test_postgres_persistence.py
+++ b/tests/test_postgres_persistence.py
@@ -1,0 +1,185 @@
+"""Real PostgreSQL persistence tests for user-owned application records."""
+import os
+import uuid
+from pathlib import Path
+from urllib.parse import quote
+
+import psycopg2
+import pytest
+
+from data_store.postgres_manager import PostgresManager
+from data_store.storage_factory import DualWriteDataManager, ShadowWriteError
+
+
+@pytest.fixture
+def postgres_manager():
+    base_dsn = os.getenv("TEST_POSTGRES_DSN")
+    if not base_dsn:
+        pytest.skip("TEST_POSTGRES_DSN is required for PostgreSQL integration tests")
+
+    schema = f"test_jobs_{uuid.uuid4().hex}"
+    admin = psycopg2.connect(base_dsn)
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cursor:
+            cursor.execute(f'CREATE SCHEMA "{schema}"')
+            cursor.execute(f'''SET search_path TO "{schema}"''')
+            cursor.execute("""
+                CREATE TABLE jobs (
+                    id SERIAL PRIMARY KEY,
+                    user_email VARCHAR(255) NOT NULL,
+                    job_title VARCHAR(500),
+                    job_description TEXT,
+                    job_date TIMESTAMP WITH TIME ZONE,
+                    job_link VARCHAR(2000),
+                    company VARCHAR(255),
+                    location VARCHAR(255),
+                    matching_score INTEGER DEFAULT 0,
+                    cv_link VARCHAR(2000),
+                    match_reasons TEXT,
+                    match_suggestions TEXT,
+                    ats_score INTEGER,
+                    hr_score INTEGER,
+                    llm_score INTEGER,
+                    hr_recommendation TEXT,
+                    matched_keywords VARCHAR(500),
+                    missing_keywords VARCHAR(500),
+                    application_status VARCHAR(40) DEFAULT 'saved',
+                    application_notes TEXT,
+                    applied_at TIMESTAMP WITH TIME ZONE,
+                    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+                    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                )
+            """)
+            cursor.execute("CREATE UNIQUE INDEX uq_jobs_user_email_job_link ON jobs(user_email, job_link)")
+
+        separator = "&" if "?" in base_dsn else "?"
+        manager_dsn = f"{base_dsn}{separator}options={quote(f'-csearch_path={schema}')}"
+        yield PostgresManager(manager_dsn)
+    finally:
+        with admin.cursor() as cursor:
+            cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        admin.close()
+
+
+def _job(url: str) -> dict:
+    return {
+        "Job Title": "Platform Engineer",
+        "Job Description": "Build reliable systems",
+        "Job Link": url,
+        "Company": "Example Co",
+        "Location": "Melbourne",
+        "score": 9,
+    }
+
+
+def test_cross_user_persistence_ownership_and_apostrophe_listing(postgres_manager):
+    url = "https://jobs.example.com/shared-listing"
+    apostrophe_owner = "o'connor@example.com"
+    other_owner = "other@example.com"
+
+    first = postgres_manager.create_job_record(_job(url), apostrophe_owner)
+    second = postgres_manager.create_job_record(_job(url), other_owner)
+
+    assert first is not None and second is not None
+    assert first["id"] != second["id"]
+    assert postgres_manager.create_job_record(_job(url), apostrophe_owner) is None
+
+    listed = postgres_manager.get_jobs_by_user(apostrophe_owner)
+    assert [record["id"] for record in listed] == [first["id"]]
+    assert listed[0]["fields"]["User Email"] == apostrophe_owner
+
+    assert postgres_manager.get_job_result(first["id"], apostrophe_owner)["id"] == first["id"]
+    assert postgres_manager.get_job_result(first["id"], other_owner) is None
+    assert postgres_manager.update_application_status(first["id"], other_owner, "applied") is None
+
+    cv_update = postgres_manager.update_cv_info(
+        url, 8, "https://files.example.com/first.pdf", user_email=apostrophe_owner
+    )
+    assert cv_update == {"id": first["id"]}
+    assert postgres_manager.get_job_result(first["id"], apostrophe_owner)["fields"]["Matching Score"] == 8
+    assert postgres_manager.get_job_result(second["id"], other_owner)["fields"]["Matching Score"] == 9
+
+    updated = postgres_manager.update_application_status(
+        first["id"], apostrophe_owner, "interviewing", "Phone screen"
+    )
+    assert updated == {"id": first["id"]}
+    persisted = postgres_manager.get_job_result(first["id"], apostrophe_owner)
+    assert persisted["fields"]["Application Status"] == "interviewing"
+    assert persisted["fields"]["Application Notes"] == "Phone screen"
+
+
+def test_dual_write_shadow_miss_is_observable_with_real_postgres(postgres_manager, caplog):
+    class AirtablePrimary:
+        def update_application_status(self, job_id, user_email, status, notes):
+            return {
+                "id": job_id,
+                "fields": {
+                    "User Email": user_email,
+                    "Job Link": "https://jobs.example.com/missing-shadow",
+                    "Application Status": status,
+                    "Application Notes": notes,
+                },
+            }
+
+    manager = DualWriteDataManager(AirtablePrimary(), postgres_manager)
+    with pytest.raises(ShadowWriteError, match="did not persist"):
+        manager.update_application_status(
+            "airtable-record", "owner@example.com", "applied", "Submitted"
+        )
+
+    assert "Postgres shadow write missed" in caplog.text
+
+
+def test_user_link_migration_is_idempotent_on_existing_postgres():
+    base_dsn = os.getenv("TEST_POSTGRES_DSN")
+    if not base_dsn:
+        pytest.skip("TEST_POSTGRES_DSN is required for PostgreSQL integration tests")
+
+    schema = f"test_migration_{uuid.uuid4().hex}"
+    migration_sql = (
+        Path(__file__).parent.parent / "init-db" / "06-jobs-user-link-uniqueness.sql"
+    ).read_text()
+    conn = psycopg2.connect(base_dsn)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(f'CREATE SCHEMA "{schema}"')
+            cursor.execute(f'SET search_path TO "{schema}"')
+            cursor.execute("""
+                CREATE TABLE jobs (
+                    id SERIAL PRIMARY KEY,
+                    user_email VARCHAR(255) NOT NULL,
+                    job_link VARCHAR(2000) UNIQUE
+                )
+            """)
+            cursor.execute(
+                "INSERT INTO jobs (user_email, job_link) VALUES (%s, %s)",
+                ("first@example.com", "https://jobs.example.com/shared"),
+            )
+
+            cursor.execute(migration_sql)
+            cursor.execute(migration_sql)
+
+            cursor.execute(
+                "INSERT INTO jobs (user_email, job_link) VALUES (%s, %s)",
+                ("second@example.com", "https://jobs.example.com/shared"),
+            )
+            cursor.execute(
+                "SELECT user_email FROM jobs WHERE job_link = %s ORDER BY user_email",
+                ("https://jobs.example.com/shared",),
+            )
+            assert [row[0] for row in cursor.fetchall()] == [
+                "first@example.com",
+                "second@example.com",
+            ]
+
+            with pytest.raises(psycopg2.errors.UniqueViolation):
+                cursor.execute(
+                    "INSERT INTO jobs (user_email, job_link) VALUES (%s, %s)",
+                    ("first@example.com", "https://jobs.example.com/shared"),
+                )
+    finally:
+        with conn.cursor() as cursor:
+            cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        conn.close()

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -133,11 +133,10 @@ class TestJobsSchema:
         missing = self.EXPECTED_COLUMNS - sql_columns
         assert not missing, f"Missing columns in jobs: {missing}"
 
-    def test_job_link_is_unique(self, schema_content):
-        """Verify job_link has UNIQUE constraint."""
-        # Check for UNIQUE in the column definition
-        assert 'job_link VARCHAR(2000) UNIQUE' in schema_content, \
-            "job_link should be UNIQUE"
+    def test_job_link_is_unique_per_user(self, schema_content):
+        """Verify duplicate URLs are prevented only within a user."""
+        assert 'job_link VARCHAR(2000) UNIQUE' not in schema_content
+        assert 'uq_jobs_user_email_job_link ON jobs(user_email, job_link)' in schema_content
 
 
 class TestCVHistorySchema:
@@ -189,6 +188,8 @@ class TestSchemaIntegrity:
         """Verify migration file exists."""
         migration_path = Path(__file__).parent.parent / "init-db" / "03-migration-v2.sql"
         assert migration_path.exists(), "Migration file should exist"
+        ownership_migration = Path(__file__).parent.parent / "init-db" / "06-jobs-user-link-uniqueness.sql"
+        assert ownership_migration.exists(), "Per-user job uniqueness migration should exist"
 
     def test_analytics_function_exists(self, schema_content):
         """Verify get_cv_analytics function is defined."""


### PR DESCRIPTION
## Summary
- Adds the Analyse → Tailor CV → Apply → Track application workspace workflow.
- Adds authenticated, user-scoped `GET /jobs/results/{id}` access.
- Persists application status and notes, with safe external apply links.
- Handles record ownership consistently across PostgreSQL and Airtable backends.

## Validation
- Backend tests: 6/6 passed
- API service tests: 4/4 passed
- Component tests: 4/4 passed
- Changed-file ESLint passed
- Production frontend build passed
- Diff check passed

No production or deployment changes are included.
