### PR TITLE
Fix reproducible Chromium package install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,14 @@ COPY requirements.in requirements.txt ./
 
 # Pin Chromium below 150 on arm64: Debian Chromium 150 currently exits with
 # SIGTRAP in the Azure production container before DrissionPage can attach.
-# Keep chromium/common/driver aligned.
+# Debian removes superseded security packages, so keep the signed snapshot that
+# contains this version available for reproducible amd64/arm64 builds.
 ARG CHROMIUM_DEB_VERSION=147.0.7727.137-1~deb12u1
+ARG CHROMIUM_SNAPSHOT=20260501T073820Z
 
-RUN apt-get update && \
+RUN echo "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/${CHROMIUM_SNAPSHOT}/ bookworm-security main" \
+        > /etc/apt/sources.list.d/chromium-snapshot.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
         build-essential gcc g++ python3-dev \


### PR DESCRIPTION
## Summary\n- retain Chromium 147 required by Azure arm64 runtime\n- source the superseded package from Debian security snapshot\n- keep chromium/common/driver versions aligned\n\n## Verification\n- exact 147 package set resolves and downloads successfully from snapshot on Debian bookworm amd64\n- deployment workflow will verify amd64/arm64 image builds after merge\n\nThis fixes the backend image failure in deployment run 30141851410.