### PR TITLE
Add applications overview and follow-up pipeline

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -186,7 +186,7 @@ jobs:
           host: ${{ secrets.AZURE_VM_HOST }}
           username: ${{ secrets.AZURE_VM_USER }}
           key: ${{ secrets.AZURE_VM_SSH_KEY }}
-          source: "docker-compose.yml,scripts/deploy.sh,scripts/prod_smoke_check.sh,scripts/prod_monitor.sh,scripts/prod_monitor_cron.sh,scripts/install_prod_monitor_cron.sh,scripts/validate_prod_config.sh,scripts/prod_migrate_db.sh,init-db/02-data-storage-schema.sql,init-db/03-migration-v2.sql,init-db/06-jobs-user-link-uniqueness.sql"
+          source: "docker-compose.yml,scripts/deploy.sh,scripts/prod_smoke_check.sh,scripts/prod_monitor.sh,scripts/prod_monitor_cron.sh,scripts/install_prod_monitor_cron.sh,scripts/validate_prod_config.sh,scripts/prod_migrate_db.sh,init-db/02-data-storage-schema.sql,init-db/03-migration-v2.sql,init-db/06-jobs-user-link-uniqueness.sql,init-db/07-jobs-next-action.sql"
           target: "~/winning-cv"
           overwrite: true
 

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -19,6 +19,8 @@ from api.middleware.auth_middleware import get_current_user
 from api.schemas.auth import UserInfo
 from api.schemas.jobs import (
     ApplicationStatusUpdate,
+    ApplicationSummary,
+    ApplicationsResponse,
     JobConfigResponse,
     JobResult,
     JobResultsResponse,
@@ -724,7 +726,38 @@ def _job_result_from_record(rec: Dict[str, Any], cv_dates: Dict[str, Any]) -> Jo
         application_status=fields.get("Application Status") or "saved",
         application_notes=fields.get("Application Notes"),
         applied_at=fields.get("Applied At"),
+        next_action_at=fields.get("Next Action At"),
     )
+
+
+def _application_summary_from_record(record: Dict[str, Any]) -> ApplicationSummary:
+    """Map a projected storage record to the applications overview contract."""
+    fields = record.get("fields", {})
+    return ApplicationSummary(
+        id=str(record.get("id", "")),
+        job_title=fields.get("Job Title") or "Untitled",
+        company=fields.get("Company") or "Unknown",
+        location=fields.get("Location"),
+        application_status=fields.get("Application Status") or "saved",
+        application_notes=fields.get("Application Notes"),
+        applied_at=fields.get("Applied At"),
+        next_action_at=fields.get("Next Action At"),
+    )
+
+
+@router.get("/applications", response_model=ApplicationsResponse)
+async def get_applications(
+    user: UserInfo = Depends(get_current_user),
+) -> ApplicationsResponse:
+    """List every application owned by the authenticated user in pipeline order."""
+    try:
+        manager = get_data_manager()
+        records = manager.get_applications_by_user(str(user.email))
+        items = [_application_summary_from_record(record) for record in records]
+        return ApplicationsResponse(items=items, total=len(items))
+    except Exception as e:
+        logger.error(f"Failed to get applications: {e}")
+        raise HTTPException(status_code=503, detail="Job storage unavailable")
 
 
 @router.get("/results", response_model=JobResultsResponse)
@@ -802,6 +835,8 @@ async def update_application_status_result(
             user_email=user.email,
             application_status=update.application_status.value,
             application_notes=update.application_notes,
+            next_action_at=update.next_action_at,
+            update_next_action="next_action_at" in update.model_fields_set,
         )
         if not updated:
             raise HTTPException(status_code=404, detail="Job not found")

--- a/api/schemas/jobs.py
+++ b/api/schemas/jobs.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import List, Optional
 
@@ -82,6 +82,28 @@ class ApplicationStatusUpdate(BaseModel):
     """Update for a job application's tracking state."""
     application_status: ApplicationStatus = Field(..., description="Current application tracking state")
     application_notes: Optional[str] = Field(None, max_length=2000, description="Private notes about the application")
+    next_action_at: Optional[date] = Field(
+        None,
+        description="Calendar date for the user's next action; explicit null clears it",
+    )
+
+
+class ApplicationSummary(BaseModel):
+    """Lightweight application data used by the overview pipeline."""
+    id: str
+    job_title: str
+    company: str
+    location: Optional[str] = None
+    application_status: ApplicationStatus = ApplicationStatus.SAVED
+    application_notes: Optional[str] = None
+    applied_at: Optional[datetime] = None
+    next_action_at: Optional[date] = None
+
+
+class ApplicationsResponse(BaseModel):
+    """Complete application overview for the authenticated user."""
+    items: List[ApplicationSummary]
+    total: int
 
 
 class JobResult(BaseModel):
@@ -102,6 +124,7 @@ class JobResult(BaseModel):
     application_status: ApplicationStatus = ApplicationStatus.SAVED
     application_notes: Optional[str] = None
     applied_at: Optional[datetime] = None
+    next_action_at: Optional[date] = None
 
 
 class JobResultsResponse(BaseModel):

--- a/data_store/airtable_manager.py
+++ b/data_store/airtable_manager.py
@@ -1,12 +1,22 @@
 import logging
-from datetime import datetime, timezone
-
-from requests import HTTPError
+from datetime import date, datetime, timezone
 
 from pyairtable.formulas import AND, EQ, NE, Field
+from requests import HTTPError
 
 from config.settings import Config
 from utils.airtable_client import create_airtable_api
+
+
+APPLICATION_SUMMARY_FIELDS = [
+    "Job Title",
+    "Company",
+    "Location",
+    "Application Status",
+    "Application Notes",
+    "Applied At",
+    "Next Action At",
+]
 
 
 class AirtableManager:
@@ -260,6 +270,8 @@ class AirtableManager:
         user_email: str,
         application_status: str,
         application_notes: str | None = None,
+        next_action_at: date | None = None,
+        update_next_action: bool = False,
     ) -> dict | None:
         """Update application tracking only when the record is exactly user-owned."""
         record = self.get_job_result(job_id, user_email)
@@ -270,9 +282,32 @@ class AirtableManager:
             "Application Status": application_status,
             "Application Notes": application_notes,
         }
+        if update_next_action:
+            fields["Next Action At"] = (
+                next_action_at.isoformat() if next_action_at is not None else None
+            )
         if application_status == "applied" and not record.get("fields", {}).get("Applied At"):
             fields["Applied At"] = datetime.now(timezone.utc).isoformat()
         return self.table.update(record["id"], fields)
+
+    def get_applications_by_user(self, user_email: str) -> list:
+        """Return projected owned applications in deterministic next-action order."""
+        formula = str(EQ(Field("User Email"), user_email))
+        records = self.table.all(
+            formula=formula,
+            fields=APPLICATION_SUMMARY_FIELDS,
+        )
+
+        def sort_key(record):
+            value = record.get("fields", {}).get("Next Action At")
+            if value:
+                try:
+                    return (0, date.fromisoformat(str(value)), record.get("id", ""))
+                except (TypeError, ValueError):
+                    pass
+            return (1, date.max, record.get("id", ""))
+
+        return sorted(records, key=sort_key)
 
     def get_jobs_by_user(self, user_email: str) -> list:
         """Return jobs owned by a user using Airtable's formula builder."""

--- a/data_store/postgres_manager.py
+++ b/data_store/postgres_manager.py
@@ -23,7 +23,7 @@ import logging
 import os
 import uuid
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
 import psycopg2
@@ -487,7 +487,7 @@ class PostgresManager:
                        cv_link, match_reasons, match_suggestions,
                        ats_score, hr_score, llm_score, hr_recommendation,
                        matched_keywords, missing_keywords, application_status,
-                       application_notes, applied_at, created_at, updated_at
+                       application_notes, applied_at, next_action_at, created_at, updated_at
                 FROM jobs
                 WHERE id::text = %s AND user_email = %s
                 LIMIT 1
@@ -521,8 +521,25 @@ class PostgresManager:
                 "Application Status": row.get("application_status") or "saved",
                 "Application Notes": row.get("application_notes"),
                 "Applied At": row.get("applied_at"),
+                "Next Action At": row.get("next_action_at"),
                 "Created At": row["created_at"].isoformat() if row["created_at"] else None,
                 "Updated At": row["updated_at"].isoformat() if row["updated_at"] else None,
+            },
+        }
+
+    @staticmethod
+    def _application_row_to_record(row: Dict) -> Dict:
+        """Convert a projected application row to the shared record shape."""
+        return {
+            "id": str(row["id"]),
+            "fields": {
+                "Job Title": row.get("job_title"),
+                "Company": row.get("company"),
+                "Location": row.get("location"),
+                "Application Status": row.get("application_status") or "saved",
+                "Application Notes": row.get("application_notes"),
+                "Applied At": row.get("applied_at"),
+                "Next Action At": row.get("next_action_at"),
             },
         }
 
@@ -539,12 +556,24 @@ class PostgresManager:
                        cv_link, match_reasons, match_suggestions,
                        ats_score, hr_score, llm_score, hr_recommendation,
                        matched_keywords, missing_keywords, application_status,
-                       application_notes, applied_at, created_at, updated_at
+                       application_notes, applied_at, next_action_at, created_at, updated_at
                 FROM jobs
                 WHERE user_email = %s
                 ORDER BY created_at DESC
             """, (user_email,))
             return [self._job_row_to_record(row) for row in cursor.fetchall()]
+
+    def get_applications_by_user(self, user_email: str) -> List[Dict]:
+        """Return projected owned applications in deterministic next-action order."""
+        with self.get_cursor() as cursor:
+            cursor.execute("""
+                SELECT id, job_title, company, location, application_status,
+                       application_notes, applied_at, next_action_at, created_at
+                FROM jobs
+                WHERE user_email = %s
+                ORDER BY next_action_at ASC NULLS LAST, created_at DESC, id ASC
+            """, (user_email,))
+            return [self._application_row_to_record(row) for row in cursor.fetchall()]
 
     def get_records_by_filter(self, formula: str) -> List[Dict]:
         """
@@ -590,7 +619,7 @@ class PostgresManager:
                            cv_link, match_reasons, match_suggestions,
                            ats_score, hr_score, llm_score, hr_recommendation,
                            matched_keywords, missing_keywords, application_status,
-                           application_notes, applied_at, created_at, updated_at
+                           application_notes, applied_at, next_action_at, created_at, updated_at
                     FROM jobs
                     WHERE {column_name} = %s
                     ORDER BY created_at DESC
@@ -610,6 +639,8 @@ class PostgresManager:
         user_email: str,
         application_status: str,
         application_notes: Optional[str] = None,
+        next_action_at: Optional[date] = None,
+        update_next_action: bool = False,
         *,
         job_link: Optional[str] = None,
     ) -> Optional[Dict]:
@@ -625,10 +656,19 @@ class PostgresManager:
                         WHEN %s = 'applied' AND applied_at IS NULL THEN NOW()
                         ELSE applied_at
                     END,
+                    next_action_at = CASE WHEN %s THEN %s ELSE next_action_at END,
                     updated_at = NOW()
                 WHERE {lookup_column} = %s AND user_email = %s
                 RETURNING id
-            """, (application_status, application_notes, application_status, lookup_value, user_email))
+            """, (
+                application_status,
+                application_notes,
+                application_status,
+                update_next_action,
+                next_action_at,
+                lookup_value,
+                user_email,
+            ))
             result = cursor.fetchone()
             return {"id": str(result["id"])} if result else None
 

--- a/data_store/storage_factory.py
+++ b/data_store/storage_factory.py
@@ -19,6 +19,7 @@ Usage:
 
 import logging
 import os
+from datetime import date
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,10 @@ class DualWriteDataManager:
 
     def get_jobs_by_user(self, user_email: str) -> List[Dict]:
         return self.airtable.get_jobs_by_user(user_email)
-    
+
+    def get_applications_by_user(self, user_email: str) -> List[Dict]:
+        return self.airtable.get_applications_by_user(user_email)
+
     def get_unprocessed_jobs(self, user_email: Optional[str] = None) -> List[Dict]:
         return self.airtable.get_unprocessed_jobs(user_email=user_email)
     
@@ -136,9 +140,16 @@ class DualWriteDataManager:
         user_email: str,
         application_status: str,
         application_notes: Optional[str] = None,
+        next_action_at: Optional[date] = None,
+        update_next_action: bool = False,
     ) -> Optional[Dict]:
         result = self.airtable.update_application_status(
-            job_id, user_email, application_status, application_notes
+            job_id,
+            user_email,
+            application_status,
+            application_notes,
+            next_action_at,
+            update_next_action,
         )
         if result is None:
             return None
@@ -149,6 +160,8 @@ class DualWriteDataManager:
                 user_email,
                 application_status,
                 application_notes,
+                next_action_at,
+                update_next_action,
                 job_link=result.get("fields", {}).get("Job Link"),
             )
         except Exception as e:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "test": "node --test src/**/*.test.js && vitest run src/pages/ApplicationWorkspace.test.jsx",
-    "test:component": "vitest run src/pages/ApplicationWorkspace.test.jsx",
+    "test": "node --test src/**/*.test.js && vitest run src/pages/*.test.jsx",
+    "test:component": "vitest run src/pages/*.test.jsx",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import UploadCV from './pages/UploadCV'
 import Preferences from './pages/Preferences'
 import GenerateCV from './pages/GenerateCV'
 import History from './pages/History'
+import Applications from './pages/Applications'
 import ApplicationWorkspace from './pages/ApplicationWorkspace'
 import Profile from './pages/Profile'
 import CVLibrary from './pages/CVLibrary'
@@ -105,6 +106,7 @@ function App() {
         <Route path="/preferences" element={<Preferences />} />
         <Route path="/generate" element={<GenerateCV />} />
         <Route path="/history" element={<History />} />
+        <Route path="/applications" element={<Applications />} />
         <Route path="/applications/:jobId" element={<ApplicationWorkspace />} />
         <Route path="/cv-library" element={<CVLibrary />} />
         <Route path="/cv-analytics" element={<CVAnalytics />} />

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -4,6 +4,7 @@ import {
   Search,
   FileText,
   Briefcase,
+  ClipboardList,
   User,
   LogOut,
   ChevronLeft,
@@ -21,6 +22,7 @@ const navigation = [
   { name: 'Generate CV', href: '/generate', icon: FileText },
   { name: 'Job Search', href: '/preferences', icon: Search },
   { name: 'Job Matches', href: '/history', icon: Briefcase },
+  { name: 'Applications', href: '/applications', icon: ClipboardList, matchNested: true },
   { name: 'Profile', href: '/profile', icon: User },
 ]
 
@@ -80,7 +82,7 @@ export default function Sidebar({ collapsed, onToggle, isMobile = false, onClose
         {/* Navigation */}
         <nav className="flex-1 py-6 px-3 space-y-1 overflow-y-auto">
           {navigation.map((item) => {
-            const isActive = location.pathname === item.href
+            const isActive = location.pathname === item.href || (item.matchNested && location.pathname.startsWith(`${item.href}/`))
             return (
               <Link
                 key={item.name}

--- a/frontend/src/pages/ApplicationWorkspace.jsx
+++ b/frontend/src/pages/ApplicationWorkspace.jsx
@@ -24,16 +24,7 @@ import {
   getSafeExternalUrl,
   getWorkflowProgress,
 } from '../utils/applicationWorkspace'
-
-const STATUS_OPTIONS = [
-  { value: 'saved', label: 'Saved' },
-  { value: 'cv_generated', label: 'CV generated' },
-  { value: 'applied', label: 'Applied' },
-  { value: 'interviewing', label: 'Interviewing' },
-  { value: 'rejected', label: 'Rejected' },
-  { value: 'offer', label: 'Offer' },
-  { value: 'archived', label: 'Archived' },
-]
+import { APPLICATION_STATUSES, toLocalDateKey } from '../utils/applicationPipeline'
 
 function ScoreCard({ icon: Icon, label, value, colour }) {
   return (
@@ -72,6 +63,7 @@ export default function ApplicationWorkspace() {
   const [loadError, setLoadError] = useState(null)
   const [status, setStatus] = useState('saved')
   const [notes, setNotes] = useState('')
+  const [nextActionAt, setNextActionAt] = useState('')
   const [saving, setSaving] = useState(false)
   const [saveMessage, setSaveMessage] = useState(null)
   const [trackingUnavailable, setTrackingUnavailable] = useState(false)
@@ -90,6 +82,7 @@ export default function ApplicationWorkspace() {
         if (selectedJob) {
           setStatus(selectedJob.application_status || 'saved')
           setNotes(selectedJob.application_notes || '')
+          setNextActionAt(toLocalDateKey(selectedJob.next_action_at))
           trackJobDetailsOpen(String(selectedJob.id), selectedJob.job_title)
         }
       } catch (error) {
@@ -125,10 +118,11 @@ export default function ApplicationWorkspace() {
     setSaveMessage(null)
     try {
       const previousStatus = job.application_status || 'saved'
-      const updatedJob = await jobService.updateApplicationStatus(job.id, status, notes)
+      const updatedJob = await jobService.updateApplicationStatus(job.id, status, notes, nextActionAt || null)
       setJob(updatedJob)
       setStatus(updatedJob.application_status || status)
       setNotes(updatedJob.application_notes || '')
+      setNextActionAt(updatedJob.next_action_at === undefined ? nextActionAt : toLocalDateKey(updatedJob.next_action_at))
       if (previousStatus !== status) trackApplicationStatusUpdate(String(job.id), status)
       setSaveMessage({ type: 'success', text: 'Application tracking saved.' })
     } catch (error) {
@@ -156,8 +150,8 @@ export default function ApplicationWorkspace() {
   if (loadError) {
     return (
       <div className="max-w-3xl mx-auto space-y-4">
-        <button type="button" onClick={() => navigate('/history')} className="btn-ghost">
-          <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to job matches
+        <button type="button" onClick={() => navigate('/applications')} className="btn-ghost">
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to applications
         </button>
         <div className="card border-red-500/30" role="alert">
           <h1 className="text-xl font-semibold text-text-primary">Workspace unavailable</h1>
@@ -170,8 +164,8 @@ export default function ApplicationWorkspace() {
   if (!job) {
     return (
       <div className="max-w-3xl mx-auto space-y-4">
-        <button type="button" onClick={() => navigate('/history')} className="btn-ghost">
-          <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to job matches
+        <button type="button" onClick={() => navigate('/applications')} className="btn-ghost">
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to applications
         </button>
         <div className="card text-center py-12">
           <Briefcase className="w-12 h-12 text-text-muted mx-auto" aria-hidden="true" />
@@ -188,8 +182,8 @@ export default function ApplicationWorkspace() {
 
   return (
     <div className="max-w-5xl mx-auto space-y-6">
-      <button type="button" onClick={() => navigate('/history')} className="btn-ghost -ml-4">
-        <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to job matches
+      <button type="button" onClick={() => navigate('/applications')} className="btn-ghost -ml-4">
+        <ArrowLeft className="w-4 h-4" aria-hidden="true" /> Back to applications
       </button>
 
       <header className="card">
@@ -291,10 +285,22 @@ export default function ApplicationWorkspace() {
                   className="input"
                   disabled={saving || trackingUnavailable}
                 >
-                  {STATUS_OPTIONS.map((option) => (
+                  {APPLICATION_STATUSES.map((option) => (
                     <option key={option.value} value={option.value}>{option.label}</option>
                   ))}
                 </select>
+              </div>
+              <div>
+                <label htmlFor="next-action-at" className="input-label">Next action date</label>
+                <input
+                  id="next-action-at"
+                  type="date"
+                  value={nextActionAt}
+                  onChange={(event) => setNextActionAt(event.target.value)}
+                  className="input"
+                  disabled={saving || trackingUnavailable}
+                />
+                <p className="mt-1 text-xs text-text-muted">Dates use your local calendar.</p>
               </div>
               <div>
                 <div className="flex items-center justify-between gap-3">

--- a/frontend/src/pages/ApplicationWorkspace.test.jsx
+++ b/frontend/src/pages/ApplicationWorkspace.test.jsx
@@ -32,6 +32,7 @@ const baseJob = {
   cv_link: null,
   application_status: 'saved',
   application_notes: null,
+  next_action_at: null,
 }
 
 function renderWorkspace() {
@@ -86,21 +87,26 @@ describe('ApplicationWorkspace', () => {
       ...baseJob,
       application_status: 'interviewing',
       application_notes: 'Phone screen booked',
+      next_action_at: '2026-08-01',
     })
     jobService.updateApplicationStatus.mockResolvedValue({
       ...baseJob,
       application_status: 'applied',
       application_notes: 'Submitted today',
+      next_action_at: '2026-08-02',
     })
 
     renderWorkspace()
 
     const status = await screen.findByLabelText('Application status')
     const notes = screen.getByLabelText('Notes')
+    const nextAction = screen.getByLabelText('Next action date')
     expect(status.value).toBe('interviewing')
     expect(notes.value).toBe('Phone screen booked')
+    expect(nextAction.value).toBe('2026-08-01')
 
     fireEvent.change(status, { target: { value: 'applied' } })
+    fireEvent.change(nextAction, { target: { value: '2026-08-03' } })
     await user.clear(notes)
     await user.type(notes, 'Sent via company portal')
     await user.click(screen.getByRole('button', { name: 'Save tracking' }))
@@ -110,11 +116,13 @@ describe('ApplicationWorkspace', () => {
         baseJob.id,
         'applied',
         'Sent via company portal',
+        '2026-08-03',
       )
     })
     expect(await screen.findByText('Application tracking saved.')).toBeTruthy()
     expect(status.value).toBe('applied')
     expect(notes.value).toBe('Submitted today')
+    expect(nextAction.value).toBe('2026-08-02')
   })
 
   it('disables tracking controls after a 501 response', async () => {
@@ -130,6 +138,7 @@ describe('ApplicationWorkspace', () => {
     expect((await screen.findByRole('alert')).textContent).toContain('Application tracking is unavailable')
     expect(screen.getByText('Application tracking is unavailable for the configured storage backend.')).toBeTruthy()
     expect(screen.getByLabelText('Application status').disabled).toBe(true)
+    expect(screen.getByLabelText('Next action date').disabled).toBe(true)
     expect(screen.getByLabelText('Notes').disabled).toBe(true)
     expect(saveButton.disabled).toBe(true)
   })

--- a/frontend/src/pages/Applications.jsx
+++ b/frontend/src/pages/Applications.jsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  AlertCircle,
+  ArrowRight,
+  BriefcaseBusiness,
+  Building2,
+  CalendarClock,
+  Loader2,
+  MapPin,
+  RefreshCw,
+} from 'lucide-react'
+import { jobService } from '../services/api'
+import {
+  APPLICATION_STATUSES,
+  getFollowUpState,
+  groupApplicationsByStatus,
+  toLocalDateKey,
+} from '../utils/applicationPipeline'
+
+const followUpStyles = {
+  overdue: 'badge-error',
+  today: 'badge-warning',
+  upcoming: 'badge-primary',
+}
+
+function ApplicationCard({ application, updating, error, onUpdate }) {
+  const followUp = getFollowUpState(application.next_action_at)
+  const workspacePath = `/applications/${encodeURIComponent(application.id)}`
+
+  return (
+    <article className="card-elevated p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <Link to={workspacePath} className="group inline-flex items-center gap-2 font-medium text-text-primary hover:text-accent-400 transition-colors">
+            <span className="truncate">{application.job_title || 'Untitled role'}</span>
+            <ArrowRight className="w-4 h-4 flex-shrink-0 opacity-0 group-hover:opacity-100" aria-hidden="true" />
+          </Link>
+          <p className="mt-1 flex items-center gap-1.5 text-sm text-text-secondary">
+            <Building2 className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+            <span className="truncate">{application.company || 'Company unavailable'}</span>
+          </p>
+          {application.location && (
+            <p className="mt-1 flex items-center gap-1.5 text-xs text-text-muted">
+              <MapPin className="w-3.5 h-3.5" aria-hidden="true" />
+              <span className="truncate">{application.location}</span>
+            </p>
+          )}
+        </div>
+        {followUp && (
+          <span className={`${followUpStyles[followUp.kind]} flex-shrink-0`}>
+            <CalendarClock className="w-3.5 h-3.5" aria-hidden="true" />
+            {followUp.label}
+          </span>
+        )}
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-3">
+        <div>
+          <label htmlFor={`status-${application.id}`} className="input-label">Status</label>
+          <select
+            id={`status-${application.id}`}
+            value={application.application_status || 'saved'}
+            onChange={(event) => onUpdate(application, { application_status: event.target.value })}
+            className="input py-2 text-sm"
+            disabled={updating}
+          >
+            {APPLICATION_STATUSES.map((status) => (
+              <option key={status.value} value={status.value}>{status.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor={`next-action-${application.id}`} className="input-label">Next action</label>
+          <input
+            id={`next-action-${application.id}`}
+            type="date"
+            value={toLocalDateKey(application.next_action_at)}
+            onChange={(event) => onUpdate(application, { next_action_at: event.target.value || null })}
+            className="input py-2 text-sm"
+            disabled={updating}
+          />
+        </div>
+      </div>
+
+      <div className="min-h-5 flex items-center justify-between gap-3">
+        {error ? (
+          <p role="alert" className="text-xs text-red-400">{error}</p>
+        ) : updating ? (
+          <p role="status" className="inline-flex items-center gap-1.5 text-xs text-text-muted">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" /> Saving changes
+          </p>
+        ) : <span />}
+        <Link to={workspacePath} className="link text-sm flex-shrink-0">Open workspace</Link>
+      </div>
+    </article>
+  )
+}
+
+export default function Applications() {
+  const [applications, setApplications] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(null)
+  const [updatingIds, setUpdatingIds] = useState(() => new Set())
+  const [updateErrors, setUpdateErrors] = useState({})
+
+  const loadApplications = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      setApplications(await jobService.getApplications())
+    } catch (error) {
+      setLoadError(error.userMessage || error.message || 'Failed to load applications.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadApplications()
+  }, [loadApplications])
+
+  const handleUpdate = async (application, updates) => {
+    const optimisticApplication = { ...application, ...updates }
+    setApplications((current) => current.map((item) =>
+      item.id === application.id ? optimisticApplication : item
+    ))
+    setUpdatingIds((current) => new Set(current).add(application.id))
+    setUpdateErrors((current) => ({ ...current, [application.id]: null }))
+
+    try {
+      const updated = await jobService.updateApplicationStatus(
+        application.id,
+        optimisticApplication.application_status || 'saved',
+        optimisticApplication.application_notes ?? null,
+        optimisticApplication.next_action_at || null,
+      )
+      setApplications((current) => current.map((item) =>
+        item.id === application.id ? { ...optimisticApplication, ...updated } : item
+      ))
+    } catch (error) {
+      setApplications((current) => current.map((item) =>
+        item.id === application.id ? application : item
+      ))
+      setUpdateErrors((current) => ({
+        ...current,
+        [application.id]: error.userMessage || error.message || 'Could not save this application.',
+      }))
+    } finally {
+      setUpdatingIds((current) => {
+        const next = new Set(current)
+        next.delete(application.id)
+        return next
+      })
+    }
+  }
+
+  const groups = groupApplicationsByStatus(applications)
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold text-text-primary">Applications</h1>
+        <p className="mt-1 text-text-secondary">Track every application and keep follow-ups moving.</p>
+      </header>
+
+      {loading ? (
+        <div className="min-h-[40vh] flex items-center justify-center" role="status">
+          <Loader2 className="w-7 h-7 text-accent-400 animate-spin" aria-hidden="true" />
+          <span className="sr-only">Loading applications</span>
+        </div>
+      ) : loadError ? (
+        <div className="card border-red-500/30 text-center" role="alert">
+          <AlertCircle className="w-10 h-10 text-red-400 mx-auto" aria-hidden="true" />
+          <h2 className="mt-3 text-lg font-semibold text-text-primary">Applications unavailable</h2>
+          <p className="mt-2 text-red-400">{loadError}</p>
+          <button type="button" onClick={loadApplications} className="btn-secondary mt-5">
+            <RefreshCw className="w-4 h-4" aria-hidden="true" /> Try again
+          </button>
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="card text-center py-12">
+          <BriefcaseBusiness className="w-12 h-12 text-text-muted mx-auto" aria-hidden="true" />
+          <h2 className="mt-4 text-lg font-semibold text-text-primary">No tracked applications yet</h2>
+          <p className="mt-2 text-text-secondary">Update a job match to begin tracking it here.</p>
+          <Link to="/history" className="btn-secondary mt-5">View job matches</Link>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {groups.map((group) => (
+            <section key={group.value} aria-labelledby={`applications-${group.value}`}>
+              <div className="mb-3 flex items-center gap-2">
+                <h2 id={`applications-${group.value}`} className="text-lg font-semibold text-text-primary">{group.label}</h2>
+                <span className="badge bg-surface-elevated text-text-secondary">{group.applications.length}</span>
+              </div>
+              <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
+                {group.applications.map((application) => (
+                  <ApplicationCard
+                    key={application.id}
+                    application={application}
+                    updating={updatingIds.has(application.id)}
+                    error={updateErrors[application.id]}
+                    onUpdate={handleUpdate}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Applications.test.jsx
+++ b/frontend/src/pages/Applications.test.jsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import Applications from './Applications'
+import { jobService } from '../services/api'
+import { toLocalDateKey } from '../utils/applicationPipeline'
+
+vi.mock('../services/api', () => ({
+  jobService: {
+    getApplications: vi.fn(),
+    updateApplicationStatus: vi.fn(),
+  },
+}))
+
+const baseApplication = {
+  id: 'job-123',
+  job_title: 'Platform Engineer',
+  company: 'Example Co',
+  location: 'Melbourne',
+  application_status: 'saved',
+  application_notes: 'Follow up after applying',
+  next_action_at: null,
+}
+
+function renderApplications() {
+  return render(
+    <MemoryRouter>
+      <Applications />
+    </MemoryRouter>,
+  )
+}
+
+function localDateOffset(days) {
+  const date = new Date()
+  date.setHours(12, 0, 0, 0)
+  date.setDate(date.getDate() + days)
+  return toLocalDateKey(date)
+}
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('Applications', () => {
+  it('shows loading, groups applications by status, and links cards to workspaces', async () => {
+    let resolveApplications
+    jobService.getApplications.mockReturnValue(new Promise((resolve) => {
+      resolveApplications = resolve
+    }))
+
+    renderApplications()
+    expect(screen.getByRole('status').textContent).toContain('Loading applications')
+
+    resolveApplications([
+      baseApplication,
+      {
+        ...baseApplication,
+        id: 'job/456',
+        job_title: 'Staff Engineer',
+        application_status: 'interviewing',
+      },
+    ])
+
+    expect(await screen.findByRole('heading', { name: 'Saved' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Interviewing' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Platform Engineer' }).getAttribute('href')).toBe('/applications/job-123')
+    expect(screen.getByRole('link', { name: 'Staff Engineer' }).getAttribute('href')).toBe('/applications/job%2F456')
+  })
+
+  it('updates status inline and regroups the application', async () => {
+    const user = userEvent.setup()
+    jobService.getApplications.mockResolvedValue([baseApplication])
+    jobService.updateApplicationStatus.mockResolvedValue({
+      ...baseApplication,
+      application_status: 'applied',
+    })
+
+    renderApplications()
+    const status = await screen.findByLabelText('Status')
+    await user.selectOptions(status, 'applied')
+
+    await waitFor(() => {
+      expect(jobService.updateApplicationStatus).toHaveBeenCalledWith(
+        'job-123',
+        'applied',
+        'Follow up after applying',
+        null,
+      )
+    })
+    expect(await screen.findByRole('heading', { name: 'Applied' })).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: 'Saved' })).toBeNull()
+  })
+
+  it('labels overdue, due-today, and upcoming follow-ups', async () => {
+    jobService.getApplications.mockResolvedValue([
+      { ...baseApplication, id: 'overdue', job_title: 'Overdue role', next_action_at: localDateOffset(-1) },
+      { ...baseApplication, id: 'today', job_title: 'Today role', next_action_at: localDateOffset(0) },
+      { ...baseApplication, id: 'upcoming', job_title: 'Upcoming role', next_action_at: localDateOffset(1) },
+    ])
+
+    renderApplications()
+
+    expect(await screen.findByText(/^Overdue ·/)).toBeTruthy()
+    expect(screen.getByText('Due today')).toBeTruthy()
+    expect(screen.getByText(/^Upcoming ·/)).toBeTruthy()
+  })
+
+  it('shows load errors and offers a retry', async () => {
+    jobService.getApplications.mockRejectedValue({ userMessage: 'Pipeline could not be loaded.' })
+
+    renderApplications()
+
+    expect(await screen.findByRole('heading', { name: 'Applications unavailable' })).toBeTruthy()
+    expect(screen.getByRole('alert').textContent).toContain('Pipeline could not be loaded.')
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy()
+  })
+
+  it('rolls back an inline edit and shows its save error', async () => {
+    jobService.getApplications.mockResolvedValue([baseApplication])
+    jobService.updateApplicationStatus.mockRejectedValue({ userMessage: 'Update failed.' })
+
+    renderApplications()
+    const nextAction = await screen.findByLabelText('Next action')
+    fireEvent.change(nextAction, { target: { value: '2026-08-01' } })
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Update failed.')
+    expect(nextAction.value).toBe('')
+  })
+})

--- a/frontend/src/pages/History.jsx
+++ b/frontend/src/pages/History.jsx
@@ -23,6 +23,7 @@ import {
 } from 'lucide-react'
 import { jobService } from '../services/api'
 import { getSafeExternalUrl } from '../utils/applicationWorkspace'
+import { APPLICATION_STATUSES } from '../utils/applicationPipeline'
 
 export default function History() {
   const navigate = useNavigate()
@@ -33,16 +34,6 @@ export default function History() {
   const [sortBy, setSortBy] = useState('date') // 'date' or 'score'
   const [expandedJob, setExpandedJob] = useState(null) // Track which job's details are expanded
   const [updatingStatus, setUpdatingStatus] = useState(null)
-
-  const applicationStatusOptions = [
-    { value: 'saved', label: 'Saved' },
-    { value: 'cv_generated', label: 'CV generated' },
-    { value: 'applied', label: 'Applied' },
-    { value: 'interviewing', label: 'Interviewing' },
-    { value: 'rejected', label: 'Rejected' },
-    { value: 'offer', label: 'Offer' },
-    { value: 'archived', label: 'Archived' },
-  ]
 
   useEffect(() => {
     loadJobs()
@@ -349,7 +340,7 @@ export default function History() {
                         disabled={updatingStatus === job.id}
                         className="input py-1 px-2 text-xs w-auto min-w-[130px]"
                       >
-                        {applicationStatusOptions.map((option) => (
+                        {APPLICATION_STATUSES.map((option) => (
                           <option key={option.value} value={option.value}>{option.label}</option>
                         ))}
                       </select>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -361,14 +361,23 @@ export const jobService = {
     return response.items || []
   },
 
-  // Update application tracking status
-  async updateApplicationStatus(jobId, applicationStatus, notes = null) {
+  // Get jobs included in the application pipeline.
+  async getApplications() {
+    const response = await fetchAPI('/api/v1/jobs/applications')
+    return Array.isArray(response) ? response : response?.items || []
+  },
+
+  // Update application tracking status and optional next action date.
+  async updateApplicationStatus(jobId, applicationStatus, notes = null, nextActionAt = undefined) {
+    const payload = {
+      application_status: applicationStatus,
+      application_notes: notes,
+    }
+    if (nextActionAt !== undefined) payload.next_action_at = nextActionAt
+
     return fetchAPI(`/api/v1/jobs/results/${encodeURIComponent(jobId)}/application`, {
       method: 'PATCH',
-      body: JSON.stringify({
-        application_status: applicationStatus,
-        application_notes: notes,
-      }),
+      body: JSON.stringify(payload),
     })
   },
 

--- a/frontend/src/services/api.test.js
+++ b/frontend/src/services/api.test.js
@@ -50,6 +50,21 @@ test('loads one matched job from the result endpoint', async () => {
   assert.equal(request.options.headers.Authorization, 'Token test-token')
 })
 
+test('loads applications from the dedicated pipeline endpoint', async () => {
+  installLocalStorage()
+  let request
+  globalThis.fetch = async (url, options) => {
+    request = { url, options }
+    return makeResponse({ items: [{ id: 'job-123', application_status: 'applied' }] })
+  }
+
+  const applications = await jobService.getApplications()
+
+  assert.deepEqual(applications, [{ id: 'job-123', application_status: 'applied' }])
+  assert.equal(request.url, 'http://localhost:8000/api/v1/jobs/applications')
+  assert.equal(request.options.credentials, 'include')
+})
+
 test('saves application tracking through the existing endpoint', async () => {
   installLocalStorage()
   let request
@@ -62,7 +77,7 @@ test('saves application tracking through the existing endpoint', async () => {
     })
   }
 
-  const result = await jobService.updateApplicationStatus('job-123', 'applied', 'Submitted today')
+  const result = await jobService.updateApplicationStatus('job-123', 'applied', 'Submitted today', '2026-07-30')
 
   assert.equal(result.application_status, 'applied')
   assert.equal(request.url, 'http://localhost:8000/api/v1/jobs/results/job-123/application')
@@ -70,6 +85,7 @@ test('saves application tracking through the existing endpoint', async () => {
   assert.deepEqual(JSON.parse(request.options.body), {
     application_status: 'applied',
     application_notes: 'Submitted today',
+    next_action_at: '2026-07-30',
   })
 })
 

--- a/frontend/src/utils/applicationPipeline.js
+++ b/frontend/src/utils/applicationPipeline.js
@@ -1,0 +1,69 @@
+export const APPLICATION_STATUSES = [
+  { value: 'saved', label: 'Saved' },
+  { value: 'cv_generated', label: 'CV generated' },
+  { value: 'applied', label: 'Applied' },
+  { value: 'interviewing', label: 'Interviewing' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'offer', label: 'Offer' },
+  { value: 'archived', label: 'Archived' },
+]
+
+const STATUS_VALUES = new Set(APPLICATION_STATUSES.map(({ value }) => value))
+
+function padDatePart(value) {
+  return String(value).padStart(2, '0')
+}
+
+export function toLocalDateKey(value) {
+  if (!value) return ''
+
+  if (typeof value === 'string') {
+    const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})(?:$|T)/)
+    if (dateOnly && !value.includes('T')) return `${dateOnly[1]}-${dateOnly[2]}-${dateOnly[3]}`
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+
+  return `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}`
+}
+
+export function getFollowUpState(nextActionAt, now = new Date()) {
+  const dateKey = toLocalDateKey(nextActionAt)
+  if (!dateKey) return null
+
+  const todayKey = toLocalDateKey(now)
+  const kind = dateKey < todayKey ? 'overdue' : dateKey === todayKey ? 'today' : 'upcoming'
+  const date = new Date(`${dateKey}T00:00:00`)
+  const formattedDate = date.toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: date.getFullYear() === now.getFullYear() ? undefined : 'numeric',
+  })
+
+  return {
+    kind,
+    dateKey,
+    label: kind === 'overdue'
+      ? `Overdue · ${formattedDate}`
+      : kind === 'today'
+        ? 'Due today'
+        : `Upcoming · ${formattedDate}`,
+  }
+}
+
+export function groupApplicationsByStatus(applications) {
+  const groups = new Map(APPLICATION_STATUSES.map((status) => [status.value, []]))
+
+  for (const application of applications || []) {
+    const status = STATUS_VALUES.has(application?.application_status)
+      ? application.application_status
+      : 'saved'
+    groups.get(status).push(application)
+  }
+
+  return APPLICATION_STATUSES.map((status) => ({
+    ...status,
+    applications: groups.get(status.value),
+  })).filter((group) => group.applications.length > 0)
+}

--- a/frontend/src/utils/applicationPipeline.test.js
+++ b/frontend/src/utils/applicationPipeline.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  getFollowUpState,
+  groupApplicationsByStatus,
+  toLocalDateKey,
+} from './applicationPipeline.js'
+
+test('groups applications in existing status order and defaults unknown statuses to saved', () => {
+  const groups = groupApplicationsByStatus([
+    { id: '3', application_status: 'interviewing' },
+    { id: '1', application_status: 'saved' },
+    { id: '2', application_status: 'applied' },
+    { id: '4', application_status: 'unexpected' },
+  ])
+
+  assert.deepEqual(groups.map(({ value }) => value), ['saved', 'applied', 'interviewing'])
+  assert.deepEqual(groups[0].applications.map(({ id }) => id), ['1', '4'])
+})
+
+test('classifies follow-ups against local calendar dates', () => {
+  const now = new Date(2026, 6, 27, 15, 30)
+
+  assert.equal(getFollowUpState('2026-07-26', now).kind, 'overdue')
+  assert.equal(getFollowUpState('2026-07-27', now).label, 'Due today')
+  assert.equal(getFollowUpState('2026-07-28', now).kind, 'upcoming')
+  assert.equal(getFollowUpState(null, now), null)
+})
+
+test('keeps HTML date values as local calendar keys', () => {
+  assert.equal(toLocalDateKey('2026-07-27'), '2026-07-27')
+  assert.equal(toLocalDateKey(new Date(2026, 6, 28, 1, 15)), '2026-07-28')
+  assert.equal(toLocalDateKey('not-a-date'), '')
+})

--- a/init-db/02-data-storage-schema.sql
+++ b/init-db/02-data-storage-schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     application_status VARCHAR(40) DEFAULT 'saved',
     application_notes TEXT,
     applied_at TIMESTAMP WITH TIME ZONE,
+    next_action_at DATE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -35,6 +36,8 @@ CREATE INDEX IF NOT EXISTS idx_jobs_job_link ON jobs(job_link);
 CREATE INDEX IF NOT EXISTS idx_jobs_user_email ON jobs(user_email);
 CREATE INDEX IF NOT EXISTS idx_jobs_created_at ON jobs(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_jobs_application_status ON jobs(application_status);
+CREATE INDEX IF NOT EXISTS idx_jobs_user_next_action
+    ON jobs(user_email, next_action_at, created_at DESC, id);
 
 -- =============================================================================
 -- cv_history: CV generation history

--- a/init-db/07-jobs-next-action.sql
+++ b/init-db/07-jobs-next-action.sql
@@ -1,0 +1,40 @@
+-- Add structured calendar-date scheduling to existing job applications.
+ALTER TABLE jobs
+    ADD COLUMN IF NOT EXISTS next_action_at DATE;
+
+-- Safely convert deployments that applied the earlier timestamp prototype.
+DO $$
+DECLARE
+    column_type TEXT;
+BEGIN
+    SELECT data_type
+      INTO column_type
+      FROM information_schema.columns
+     WHERE table_schema = current_schema()
+       AND table_name = 'jobs'
+       AND column_name = 'next_action_at';
+
+    IF column_type = 'timestamp with time zone' THEN
+        EXECUTE 'ALTER TABLE jobs ALTER COLUMN next_action_at TYPE DATE '
+             || 'USING (next_action_at AT TIME ZONE ''UTC'')::date';
+    ELSIF column_type = 'timestamp without time zone' THEN
+        EXECUTE 'ALTER TABLE jobs ALTER COLUMN next_action_at TYPE DATE '
+             || 'USING next_action_at::date';
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM pg_indexes
+         WHERE schemaname = current_schema()
+           AND indexname = 'idx_jobs_user_next_action'
+           AND indexdef NOT LIKE '%(user_email, next_action_at, created_at DESC, id)%'
+    ) THEN
+        EXECUTE 'DROP INDEX idx_jobs_user_next_action';
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_jobs_user_next_action
+    ON jobs(user_email, next_action_at, created_at DESC, id);

--- a/scripts/prod_migrate_db.sh
+++ b/scripts/prod_migrate_db.sh
@@ -19,3 +19,4 @@ SQL
 
 # Apply file-backed migrations that alter constraints/indexes.
 docker exec -i "$POSTGRES_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 < init-db/06-jobs-user-link-uniqueness.sql
+docker exec -i "$POSTGRES_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 < init-db/07-jobs-next-action.sql

--- a/tests/test_job_result_workspace.py
+++ b/tests/test_job_result_workspace.py
@@ -1,17 +1,18 @@
 """Focused tests for the application workspace job-result routes."""
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from unittest.mock import Mock
 
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 from requests import HTTPError, Response
 
-import pytest
-from fastapi import HTTPException
-
+from api.middleware.auth_middleware import get_current_user
 from api.routes import jobs
 from api.schemas.auth import UserInfo
 from api.schemas.jobs import ApplicationStatusUpdate
-from data_store.airtable_manager import AirtableManager
+from data_store.airtable_manager import APPLICATION_SUMMARY_FIELDS, AirtableManager
 from data_store.postgres_manager import PostgresManager
 from data_store.storage_factory import DualWriteDataManager, ShadowWriteError
 
@@ -24,6 +25,14 @@ def make_user(email: str = "owner@example.com") -> UserInfo:
         provider="test",
         is_verified=True,
     )
+
+
+def make_test_client(user: UserInfo | None = None) -> TestClient:
+    app = FastAPI()
+    app.include_router(jobs.router, prefix="/api/v1")
+    if user is not None:
+        app.dependency_overrides[get_current_user] = lambda: user
+    return TestClient(app)
 
 
 def make_record(**field_overrides):
@@ -40,6 +49,52 @@ def make_record(**field_overrides):
     }
     fields.update(field_overrides)
     return {"id": "job-123", "fields": fields}
+
+
+def test_applications_route_requires_authentication():
+    response = make_test_client().get("/api/v1/jobs/applications")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+
+
+def test_applications_route_is_user_scoped_and_not_truncated(monkeypatch):
+    next_action = date(2026, 7, 28)
+    records = []
+    for index in range(101):
+        record = make_record(**{"Next Action At": next_action.isoformat()})
+        record["id"] = f"job-{index:03d}"
+        records.append(record)
+
+    manager = Mock()
+    manager.get_applications_by_user.return_value = records
+
+    def fail_history_dependency():
+        pytest.fail("applications overview must not resolve CV history storage")
+
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
+    monkeypatch.setattr(jobs, "get_history_manager", fail_history_dependency)
+
+    response = make_test_client(make_user("o'connor@example.com")).get(
+        "/api/v1/jobs/applications"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 101
+    assert len(response.json()["items"]) == 101
+    first_item = response.json()["items"][0]
+    assert first_item["next_action_at"] == "2026-07-28"
+    assert set(first_item) == {
+        "id",
+        "job_title",
+        "company",
+        "location",
+        "application_status",
+        "application_notes",
+        "applied_at",
+        "next_action_at",
+    }
+    manager.get_applications_by_user.assert_called_once_with("o'connor@example.com")
 
 
 @pytest.mark.asyncio
@@ -85,6 +140,7 @@ async def test_update_application_status_returns_saved_job(monkeypatch):
     def update_application_status(**kwargs):
         record["fields"]["Application Status"] = kwargs["application_status"]
         record["fields"]["Application Notes"] = kwargs["application_notes"]
+        record["fields"]["Next Action At"] = kwargs["next_action_at"]
         return {"id": kwargs["job_id"]}
 
     manager.update_application_status.side_effect = update_application_status
@@ -96,17 +152,77 @@ async def test_update_application_status_returns_saved_job(monkeypatch):
 
     result = await jobs.update_application_status_result(
         "job-123",
-        ApplicationStatusUpdate(application_status="applied", application_notes="Submitted today"),
+        ApplicationStatusUpdate(
+            application_status="applied",
+            application_notes="Submitted today",
+            next_action_at="2026-07-30",
+        ),
         make_user(),
     )
 
     assert result.application_status.value == "applied"
     assert result.application_notes == "Submitted today"
+    assert result.next_action_at == date(2026, 7, 30)
     manager.update_application_status.assert_called_once_with(
         job_id="job-123",
         user_email="owner@example.com",
         application_status="applied",
         application_notes="Submitted today",
+        next_action_at=date(2026, 7, 30),
+        update_next_action=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_application_status_preserves_omitted_next_action(monkeypatch):
+    manager = Mock()
+    manager.update_application_status.return_value = {"id": "job-123"}
+    manager.get_job_result.return_value = make_record()
+    history_manager = Mock()
+    history_manager.get_history_by_user.return_value = []
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
+    monkeypatch.setattr(jobs, "get_history_manager", lambda: history_manager)
+
+    await jobs.update_application_status_result(
+        "job-123",
+        ApplicationStatusUpdate(application_status="interviewing"),
+        make_user(),
+    )
+
+    assert manager.update_application_status.call_args.kwargs["update_next_action"] is False
+
+
+def test_update_application_route_rejects_timestamp_next_action():
+    response = make_test_client(make_user()).patch(
+        "/api/v1/jobs/results/job-123/application",
+        json={
+            "application_status": "interviewing",
+            "next_action_at": "2026-07-30T23:30:00-05:00",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_application_route_hides_foreign_job(monkeypatch):
+    manager = Mock()
+    manager.update_application_status.return_value = None
+    monkeypatch.setattr(jobs, "get_data_manager", lambda: manager)
+
+    response = make_test_client(make_user()).patch(
+        "/api/v1/jobs/results/foreign-job/application",
+        json={"application_status": "applied", "next_action_at": None},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Job not found"
+    manager.update_application_status.assert_called_once_with(
+        job_id="foreign-job",
+        user_email="owner@example.com",
+        application_status="applied",
+        application_notes=None,
+        next_action_at=None,
+        update_next_action=True,
     )
 
 
@@ -147,6 +263,7 @@ def test_postgres_job_lookup_parameterizes_apostrophe_email():
         "application_status": "saved",
         "application_notes": None,
         "applied_at": None,
+        "next_action_at": date(2026, 7, 30),
         "created_at": None,
         "updated_at": None,
     }
@@ -162,6 +279,7 @@ def test_postgres_job_lookup_parameterizes_apostrophe_email():
     result = manager.get_job_result(row["id"], row["user_email"])
 
     assert result["id"] == row["id"]
+    assert result["fields"]["Next Action At"] == row["next_action_at"]
     query, params = cursor.execute.call_args.args
     assert "WHERE id::text = %s AND user_email = %s" in query
     assert params == (row["id"], "o'connor@example.com")
@@ -181,6 +299,56 @@ def test_postgres_list_jobs_parameterizes_apostrophe_email():
     query, params = cursor.execute.call_args.args
     assert "WHERE user_email = %s" in query
     assert params == ("o'connor@example.com",)
+
+def test_postgres_application_list_is_projected_owner_scoped_and_ordered():
+    cursor = Mock()
+    cursor.fetchall.return_value = [
+        {
+            "id": 42,
+            "job_title": "Platform Engineer",
+            "company": "Example Co",
+            "location": "Melbourne",
+            "application_status": "interviewing",
+            "application_notes": "Phone screen",
+            "applied_at": datetime(2026, 7, 20, 9, 0, tzinfo=timezone.utc),
+            "next_action_at": date(2026, 7, 30),
+            "created_at": datetime(2026, 7, 19, 9, 0, tzinfo=timezone.utc),
+        }
+    ]
+    manager = PostgresManager("postgresql://unused")
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    manager.get_cursor = fake_cursor
+    result = manager.get_applications_by_user("o'connor@example.com")
+
+    assert result == [
+        {
+            "id": "42",
+            "fields": {
+                "Job Title": "Platform Engineer",
+                "Company": "Example Co",
+                "Location": "Melbourne",
+                "Application Status": "interviewing",
+                "Application Notes": "Phone screen",
+                "Applied At": datetime(2026, 7, 20, 9, 0, tzinfo=timezone.utc),
+                "Next Action At": date(2026, 7, 30),
+            },
+        }
+    ]
+    query, params = cursor.execute.call_args.args
+    projection = query.split("FROM jobs", 1)[0]
+    assert "job_description" not in projection
+    assert "job_link" not in projection
+    assert "matching_score" not in projection
+    assert "cv_link" not in projection
+    assert "WHERE user_email = %s" in query
+    assert "ORDER BY next_action_at ASC NULLS LAST, created_at DESC, id ASC" in query
+    assert "LIMIT" not in query.upper()
+    assert params == ("o'connor@example.com",)
+
 
 def test_airtable_job_lookup_checks_exact_owner_without_formula():
     manager = AirtableManager.__new__(AirtableManager)
@@ -235,9 +403,43 @@ def test_postgres_application_update_is_owner_scoped_and_persists():
         "applied",
         "Submitted today",
         "applied",
+        False,
+        None,
         "d5b0fbe6-1e2b-4e65-90b0-2bb092f66d14",
         "owner@example.com",
     )
+
+
+@pytest.mark.parametrize(
+    ("next_action_at", "expected"),
+    [
+        (date(2026, 7, 30), date(2026, 7, 30)),
+        (None, None),
+    ],
+)
+def test_postgres_application_update_sets_or_clears_next_action(next_action_at, expected):
+    cursor = Mock()
+    cursor.fetchone.return_value = {"id": 42}
+    manager = PostgresManager("postgresql://unused")
+
+    @contextmanager
+    def fake_cursor():
+        yield cursor
+
+    manager.get_cursor = fake_cursor
+    manager.update_application_status(
+        "42",
+        "owner@example.com",
+        "interviewing",
+        None,
+        next_action_at,
+        True,
+    )
+
+    query, params = cursor.execute.call_args.args
+    assert "next_action_at = CASE WHEN %s THEN %s ELSE next_action_at END" in query
+    assert params[3:5] == (True, expected)
+    assert params[-2:] == ("42", "owner@example.com")
 
 
 def test_postgres_application_update_denies_cross_user():
@@ -303,6 +505,63 @@ def test_airtable_application_update_persists_for_exact_owner():
     assert datetime.fromisoformat(fields["Applied At"]).tzinfo is not None
 
 
+@pytest.mark.parametrize(
+    ("next_action_at", "expected"),
+    [
+        (date(2026, 7, 30), "2026-07-30"),
+        (None, None),
+    ],
+)
+def test_airtable_application_update_sets_or_clears_next_action(next_action_at, expected):
+    manager = AirtableManager.__new__(AirtableManager)
+    manager.table = Mock()
+    manager.logger = Mock()
+    manager.table.get.return_value = make_record()
+    manager.table.update.return_value = make_record(**{"Next Action At": expected})
+
+    manager.update_application_status(
+        "job-123",
+        "owner@example.com",
+        "interviewing",
+        None,
+        next_action_at,
+        True,
+    )
+
+    _, fields = manager.table.update.call_args.args
+    assert fields["Next Action At"] == expected
+
+
+def test_airtable_application_list_projects_owner_scoped_fields_and_orders_dates():
+    manager = AirtableManager.__new__(AirtableManager)
+    manager.table = Mock()
+    manager.logger = Mock()
+    overdue = make_record(**{"Next Action At": "2026-07-26"})
+    overdue["id"] = "overdue"
+    upcoming = make_record(**{"Next Action At": "2026-07-30"})
+    upcoming["id"] = "upcoming"
+    unscheduled = make_record()
+    unscheduled["id"] = "unscheduled"
+    manager.table.all.return_value = [unscheduled, upcoming, overdue]
+
+    result = manager.get_applications_by_user("o'connor@example.com")
+
+    assert [record["id"] for record in result] == ["overdue", "upcoming", "unscheduled"]
+    kwargs = manager.table.all.call_args.kwargs
+    assert kwargs["fields"] == APPLICATION_SUMMARY_FIELDS
+    assert kwargs["fields"] == [
+        "Job Title",
+        "Company",
+        "Location",
+        "Application Status",
+        "Application Notes",
+        "Applied At",
+        "Next Action At",
+    ]
+    assert "User Email" in kwargs["formula"]
+    assert "o\\'connor@example.com" in kwargs["formula"]
+
+
 def test_airtable_application_update_denies_cross_user():
     manager = AirtableManager.__new__(AirtableManager)
     manager.table = Mock()
@@ -336,6 +595,19 @@ def test_airtable_lookup_propagates_backend_failure():
         manager.get_job_result("job-123", "owner@example.com")
 
 
+def test_dual_write_application_list_reads_from_airtable_primary():
+    airtable = Mock()
+    postgres = Mock()
+    airtable.get_applications_by_user.return_value = [make_record()]
+    manager = DualWriteDataManager(airtable, postgres)
+
+    result = manager.get_applications_by_user("owner@example.com")
+
+    assert len(result) == 1
+    airtable.get_applications_by_user.assert_called_once_with("owner@example.com")
+    postgres.get_applications_by_user.assert_not_called()
+
+
 def test_dual_write_application_update_uses_airtable_primary_and_postgres_shadow():
     airtable = Mock()
     postgres = Mock()
@@ -348,13 +620,15 @@ def test_dual_write_application_update_uses_airtable_primary_and_postgres_shadow
 
     assert result["id"] == "job-123"
     airtable.update_application_status.assert_called_once_with(
-        "job-123", "owner@example.com", "interviewing", "Phone screen"
+        "job-123", "owner@example.com", "interviewing", "Phone screen", None, False
     )
     postgres.update_application_status.assert_called_once_with(
         "job-123",
         "owner@example.com",
         "interviewing",
         "Phone screen",
+        None,
+        False,
         job_link="https://jobs.example.com/123",
     )
 

--- a/tests/test_postgres_persistence.py
+++ b/tests/test_postgres_persistence.py
@@ -1,6 +1,7 @@
 """Real PostgreSQL persistence tests for user-owned application records."""
 import os
 import uuid
+from datetime import date
 from pathlib import Path
 from urllib.parse import quote
 
@@ -47,6 +48,7 @@ def postgres_manager():
                     application_status VARCHAR(40) DEFAULT 'saved',
                     application_notes TEXT,
                     applied_at TIMESTAMP WITH TIME ZONE,
+                    next_action_at DATE,
                     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
                     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
                 )
@@ -101,17 +103,31 @@ def test_cross_user_persistence_ownership_and_apostrophe_listing(postgres_manage
     assert postgres_manager.get_job_result(second["id"], other_owner)["fields"]["Matching Score"] == 9
 
     updated = postgres_manager.update_application_status(
-        first["id"], apostrophe_owner, "interviewing", "Phone screen"
+        first["id"],
+        apostrophe_owner,
+        "interviewing",
+        "Phone screen",
+        date(2026, 7, 30),
+        True,
     )
     assert updated == {"id": first["id"]}
     persisted = postgres_manager.get_job_result(first["id"], apostrophe_owner)
     assert persisted["fields"]["Application Status"] == "interviewing"
     assert persisted["fields"]["Application Notes"] == "Phone screen"
+    assert persisted["fields"]["Next Action At"] == date(2026, 7, 30)
 
 
 def test_dual_write_shadow_miss_is_observable_with_real_postgres(postgres_manager, caplog):
     class AirtablePrimary:
-        def update_application_status(self, job_id, user_email, status, notes):
+        def update_application_status(
+            self,
+            job_id,
+            user_email,
+            status,
+            notes,
+            next_action_at,
+            update_next_action,
+        ):
             return {
                 "id": job_id,
                 "fields": {
@@ -129,6 +145,64 @@ def test_dual_write_shadow_miss_is_observable_with_real_postgres(postgres_manage
         )
 
     assert "Postgres shadow write missed" in caplog.text
+
+
+def test_next_action_migration_is_idempotent_and_replaces_old_index():
+    base_dsn = os.getenv("TEST_POSTGRES_DSN")
+    if not base_dsn:
+        pytest.skip("TEST_POSTGRES_DSN is required for PostgreSQL integration tests")
+
+    schema = f"test_next_action_migration_{uuid.uuid4().hex}"
+    migration_sql = (
+        Path(__file__).parent.parent / "init-db" / "07-jobs-next-action.sql"
+    ).read_text()
+    conn = psycopg2.connect(base_dsn)
+    conn.autocommit = True
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(f'CREATE SCHEMA "{schema}"')
+            cursor.execute(f'SET search_path TO "{schema}"')
+            cursor.execute("""
+                CREATE TABLE jobs (
+                    id SERIAL PRIMARY KEY,
+                    user_email VARCHAR(255) NOT NULL,
+                    next_action_at TIMESTAMP WITH TIME ZONE,
+                    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                )
+            """)
+            cursor.execute(
+                "CREATE INDEX idx_jobs_user_next_action "
+                "ON jobs(user_email, next_action_at, id)"
+            )
+            cursor.execute(
+                "INSERT INTO jobs (user_email, next_action_at) VALUES (%s, %s)",
+                ("owner@example.com", "2026-07-30T23:30:00-05:00"),
+            )
+
+            cursor.execute(migration_sql)
+            cursor.execute(migration_sql)
+
+            cursor.execute("""
+                SELECT data_type
+                FROM information_schema.columns
+                WHERE table_schema = %s
+                  AND table_name = 'jobs'
+                  AND column_name = 'next_action_at'
+            """, (schema,))
+            assert cursor.fetchone()[0] == "date"
+            cursor.execute("SELECT next_action_at FROM jobs")
+            assert cursor.fetchone()[0] == date(2026, 7, 31)
+            cursor.execute("""
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE schemaname = %s
+                  AND indexname = 'idx_jobs_user_next_action'
+            """, (schema,))
+            assert "(user_email, next_action_at, created_at DESC, id)" in cursor.fetchone()[0]
+    finally:
+        with conn.cursor() as cursor:
+            cursor.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        conn.close()
 
 
 def test_user_link_migration_is_idempotent_on_existing_postgres():

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -123,6 +123,7 @@ class TestJobsSchema:
         'job_link', 'company', 'location', 'matching_score', 'cv_link',
         'match_reasons', 'match_suggestions', 'ats_score', 'hr_score',
         'llm_score', 'hr_recommendation', 'matched_keywords', 'missing_keywords',
+        'application_status', 'application_notes', 'applied_at', 'next_action_at',
         'created_at', 'updated_at',
     }
 
@@ -137,6 +138,15 @@ class TestJobsSchema:
         """Verify duplicate URLs are prevented only within a user."""
         assert 'job_link VARCHAR(2000) UNIQUE' not in schema_content
         assert 'uq_jobs_user_email_job_link ON jobs(user_email, job_link)' in schema_content
+
+    def test_next_action_is_calendar_date(self, schema_content):
+        """Verify next actions cannot acquire timezone-sensitive timestamps."""
+        assert "next_action_at DATE" in schema_content
+        assert "next_action_at TIMESTAMP" not in schema_content
+        assert (
+            "ON jobs(user_email, next_action_at, created_at DESC, id)"
+            in schema_content
+        )
 
 
 class TestCVHistorySchema:
@@ -190,6 +200,30 @@ class TestSchemaIntegrity:
         assert migration_path.exists(), "Migration file should exist"
         ownership_migration = Path(__file__).parent.parent / "init-db" / "06-jobs-user-link-uniqueness.sql"
         assert ownership_migration.exists(), "Per-user job uniqueness migration should exist"
+        next_action_migration = Path(__file__).parent.parent / "init-db" / "07-jobs-next-action.sql"
+        assert next_action_migration.exists(), "Next-action migration should exist"
+
+    def test_next_action_migration_is_idempotent_and_indexed(self):
+        migration_path = Path(__file__).parent.parent / "init-db" / "07-jobs-next-action.sql"
+        migration = migration_path.read_text()
+
+        assert "ADD COLUMN IF NOT EXISTS next_action_at DATE" in migration
+        assert "ALTER COLUMN next_action_at TYPE DATE" in migration
+        assert "AT TIME ZONE ''UTC''" in migration
+        assert "CREATE INDEX IF NOT EXISTS idx_jobs_user_next_action" in migration
+        assert "ON jobs(user_email, next_action_at, created_at DESC, id)" in migration
+        assert "indexdef NOT LIKE" in migration
+
+    def test_next_action_migration_is_wired_into_production_artifacts(self):
+        project_root = Path(__file__).parent.parent
+        migration_script = (project_root / "scripts" / "prod_migrate_db.sh").read_text()
+        build_workflow = (
+            project_root / ".github" / "workflows" / "build-push.yml"
+        ).read_text()
+
+        migration_name = "init-db/07-jobs-next-action.sql"
+        assert f"< {migration_name}" in migration_script
+        assert migration_name in build_workflow
 
     def test_analytics_function_exists(self, schema_content):
         """Verify get_cv_analytics function is defined."""


### PR DESCRIPTION
## Summary
- add a protected Applications sidebar route with a status-grouped overview, inline status/next-action editing, overdue/upcoming indicators, and links to each Application Workspace
- add a lightweight authenticated applications API and date-only next-action persistence across PostgreSQL, Airtable, and dual-write storage
- add the idempotent PostgreSQL migration to the existing deployment migration path and centralize shared application status/date UI helpers

## Security
- list and update operations are scoped to the authenticated user's email at both route and storage layers
- cross-user record IDs return not found and are covered by PostgreSQL, Airtable, dual-write, and route-level IDOR tests
- application summaries expose only fields required by the overview; no job description, scoring detail, CV history, or other users' records are returned

## Verification
- `python3 -m pytest -q tests/test_job_result_workspace.py tests/test_postgres_schema.py tests/test_postgres_persistence.py` — 55 passed, 4 skipped (`TEST_POSTGRES_DSN` not configured), 3 dependency deprecation warnings
- `python3 -m pytest tests/test_utils.py tests/test_settings.py tests/test_postgres_schema.py tests/test_api_integration.py tests/test_task_queue.py tests/test_job_result_workspace.py tests/test_postgres_persistence.py tests/test_job_processor.py -q` — 154 passed, 4 skipped, 3 dependency deprecation warnings
- `npm --prefix frontend test` — 12 Node tests and 10 component tests passed
- `npm --prefix frontend run lint` — passed with 0 errors and 16 pre-existing warnings
- `npm --prefix frontend run build` — passed with the existing telemetry chunking warning
- `python3 -m ruff check . --select=E9,F63,F7,F82` — passed
- `python3 -m compileall -q api data_store` — passed
- `bash -n scripts/prod_migrate_db.sh` — passed
- `git diff --check origin/main...HEAD` — passed

## Baseline findings
- full `python3 -m pytest -q` remains red outside this slice: 209 passed, 5 skipped, 4 failed, 2 errors due to existing live scraper/config tests, obsolete logger-call expectations, and missing Azure AI credentials
- repository-wide unrestricted Ruff/format checks remain red on pre-existing lint and formatting debt; CI-critical Ruff rules pass
- no TypeScript/typecheck script exists; the frontend is JavaScript/JSX

## Follow-up
- existing PostgreSQL deployments receive `init-db/07-jobs-next-action.sql` through the migration script on a future deployment
- Airtable installations must have a `Next Action At` date field before date updates are used
- cursor pagination/virtualization can be added if per-user application volumes grow substantially; this slice intentionally returns the complete lightweight overview rather than silently truncating at 100

## Test plan
- [x] Verify owner-scoped list and cross-user read/update denial
- [x] Verify next-action date set, clear, ordering, and migration idempotency
- [x] Verify overview grouping, inline edits, urgency labels, and workspace links
- [x] Run targeted and curated backend suites
- [x] Run frontend tests, lint, and production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)